### PR TITLE
[Docs] springdoc, swagger 를 이용한 API 명세서 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 
 	//jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.5'
+
+	//spring-doc
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ku/covigator/config/AuthConfig.java
+++ b/src/main/java/com/ku/covigator/config/AuthConfig.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
-public class WebConfig implements WebMvcConfigurer {
+public class AuthConfig implements WebMvcConfigurer {
 
     private final JwtAuthInterceptor jwtAuthInterceptor;
     private final JwtAuthArgumentResolver jwtAuthArgumentResolver;
@@ -20,8 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAuthInterceptor)
-                .addPathPatterns("/**")
-                .excludePathPatterns("/accounts/**");
+                .addPathPatterns("/members/travel-styles");
     }
 
     @Override

--- a/src/main/java/com/ku/covigator/config/SwaggerConfig.java
+++ b/src/main/java/com/ku/covigator/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.ku.covigator.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Covigator API",
+                description = "Covigator API 명세서입니다.",
+                version = "1.0.0"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("jwt token");
+        Components components = new Components().addSecuritySchemes("jwt token", new SecurityScheme()
+                .name(HttpHeaders.AUTHORIZATION)
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+
+        return new OpenAPI()
+                .components(new Components())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+
+    }
+
+}

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -5,10 +5,13 @@ import com.ku.covigator.dto.request.PostSignUpRequest;
 import com.ku.covigator.dto.response.AccessTokenResponse;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증/인가")
 @RestController
 @RequestMapping("/accounts")
 @RequiredArgsConstructor
@@ -16,18 +19,21 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "로컬 로그인")
     @PostMapping("/sign-in")
     public ResponseEntity<AccessTokenResponse> signIn(@RequestBody PostSignInRequest request) {
         String accessToken = authService.signIn(request.email(), request.password());
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
     }
 
+    @Operation(summary = "회원가입")
     @PostMapping("sign-up")
     public ResponseEntity<AccessTokenResponse> signUp(@RequestBody PostSignUpRequest request) {
         String accessToken = authService.signUp(request.toEntity());
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
     }
 
+    @Operation(summary = "카카오 로그인")
     @GetMapping("/oauth/kakao")
     public ResponseEntity<KakaoSignInResponse> signInKakao(@RequestParam String code) {
         return ResponseEntity.ok(authService.signInKakao(code));

--- a/src/main/java/com/ku/covigator/controller/TravelStyleController.java
+++ b/src/main/java/com/ku/covigator/controller/TravelStyleController.java
@@ -4,10 +4,13 @@ import com.ku.covigator.dto.request.PatchTravelStyleRequest;
 import com.ku.covigator.dto.request.PostTravelStyleRequest;
 import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.TravelStyleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Travel Style", description = "여행 스타일")
 @RestController
 @RequestMapping("/members/travel-styles")
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ public class TravelStyleController {
 
     private final TravelStyleService travelStyleService;
 
+    @Operation(summary = "여행 스타일 저장")
     @PostMapping
     public ResponseEntity<Void> saveTravelStyle(@LoggedInMemberId Long memberId,
                                                 @RequestBody PostTravelStyleRequest request) {
@@ -22,6 +26,7 @@ public class TravelStyleController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "여행 스타일 수정")
     @PatchMapping
     public ResponseEntity<Void> patchTravelStyle(@LoggedInMemberId Long memberId,
                                                  @RequestBody PatchTravelStyleRequest request) {

--- a/src/main/java/com/ku/covigator/repository/MemberRepository.java
+++ b/src/main/java/com/ku/covigator/repository/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
     Optional<Member> findByEmailAndPlatform(String email, Platform platform);
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,7 @@ security:
       redirect-uri: ${REDIRECT_URI}
       user-info-url: https://kapi.kakao.com/v2/user/me
       token-url: https://kauth.kakao.com/oauth/token
+
+springdoc:
+  swagger-ui:
+    path: "/api-doc"


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #13 

## 📝 작업사항

- [X] springdoc, swagger 적용
- [X] swagger 환경설정 (jwt 토큰 적용)

## 📦 ETC

<img width="243" alt="스크린샷 2024-06-04 오후 1 11 00" src="https://github.com/Covigator/Covigator-BE/assets/57056933/ea186ce3-32c7-4b40-9fb4-d3e3bb1cfd05">

api 명세서의 기본 경로를 `/api-doc`으로 설정
- 해당 주소로 접근하면 `http://localhost:8080/swagger-ui/index.html`로 리다이렉션된다.