### PR TITLE
[Feat] 장소 조회 API 구현

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,14 +17,6 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    env:
-      REST_API_KEY: ${{ secrets.REST_API_KEY}}
-      REDIRECT_URI: ${{ secrets.REDIRECT_URI }}
-      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-      JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,14 +10,18 @@ on:
       - main
       - develop
 
-env:
-  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-  JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
-
 jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
+    env:
+      REST_API_KEY: ${{ secrets.REST_API_KEY}}
+      REDIRECT_URI: ${{ secrets.REDIRECT_URI }}
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+      JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v3
@@ -42,10 +46,6 @@ jobs:
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
       - name: Build and analyze
         env:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  RESOURCE_PATH: ../../src/main/resources/application.yml
+  RESOURCE_PATH: ./src/main/resources/application.yml
 
 jobs:
   build:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - develop
 
+env:
+  RESOURCE_PATH: ../../src/main/resources/application.yml
+
 jobs:
   build:
     name: Build and analyze
@@ -30,6 +33,18 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      - name: Set yml file
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ${{ env.RESOURCE_PATH }}
+        env:
+          spring.datasource.url: ${{ secrets.DATABASE_URL }}
+          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
+          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
+          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
+          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
+          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,6 +26,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Connect to MySQL
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'covigator'
+          mysql user: ${{ secrets.DATABASE_USERNAME }}
+          mysql password: ${{ secrets.DATABASE_PASSWORD }}
+
       - name: Set yml file
         uses: microsoft/variable-substitution@v1
         with:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,8 +10,12 @@ on:
       - main
       - develop
 
+#env:
+#  RESOURCE_PATH: ./src/main/resources/application.yml
+
 env:
-  RESOURCE_PATH: ./src/main/resources/application.yml
+  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+  JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
 
 jobs:
   build:
@@ -26,29 +30,29 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Shutdown Ubuntu MySQL (SUDO)
-        run: sudo service mysql stop
+#      - name: Shutdown Ubuntu MySQL (SUDO)
+#        run: sudo service mysql stop
+#
+#      - name: Connect to MySQL
+#        uses: mirromutth/mysql-action@v1.1
+#        with:
+#          host port: 3306
+#          container port: 3306
+#          mysql database: 'covigator'
+#          mysql user: ${{ secrets.DATABASE_USERNAME }}
+#          mysql password: ${{ secrets.DATABASE_PASSWORD }}
 
-      - name: Connect to MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          host port: 3306
-          container port: 3306
-          mysql database: 'covigator'
-          mysql user: ${{ secrets.DATABASE_USERNAME }}
-          mysql password: ${{ secrets.DATABASE_PASSWORD }}
-
-      - name: Set yml file
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: ${{ env.RESOURCE_PATH }}
-        env:
-          spring.datasource.url: ${{ secrets.DATABASE_URL }}
-          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
-          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
-          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
-          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
-          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
+#      - name: Set yml file
+#        uses: microsoft/variable-substitution@v1
+#        with:
+#          files: ${{ env.RESOURCE_PATH }}
+#        env:
+#          spring.datasource.url: ${{ secrets.DATABASE_URL }}
+#          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
+#          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
+#          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
+#          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
+#          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 9.0
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,6 +13,9 @@ on:
 env:
   JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
   JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+  DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
 jobs:
   build:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-version: 9.0
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,9 +10,6 @@ on:
       - main
       - develop
 
-#env:
-#  RESOURCE_PATH: ./src/main/resources/application.yml
-
 env:
   JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
   JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
@@ -29,30 +26,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-#      - name: Shutdown Ubuntu MySQL (SUDO)
-#        run: sudo service mysql stop
-#
-#      - name: Connect to MySQL
-#        uses: mirromutth/mysql-action@v1.1
-#        with:
-#          host port: 3306
-#          container port: 3306
-#          mysql database: 'covigator'
-#          mysql user: ${{ secrets.DATABASE_USERNAME }}
-#          mysql password: ${{ secrets.DATABASE_PASSWORD }}
-
-#      - name: Set yml file
-#        uses: microsoft/variable-substitution@v1
-#        with:
-#          files: ${{ env.RESOURCE_PATH }}
-#        env:
-#          spring.datasource.url: ${{ secrets.DATABASE_URL }}
-#          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
-#          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
-#          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
-#          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
-#          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,6 +26,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Shutdown Ubuntu MySQL (SUDO)
+        run: sudo service mysql stop
+
       - name: Connect to MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
@@ -34,6 +37,18 @@ jobs:
           mysql database: 'covigator'
           mysql user: ${{ secrets.DATABASE_USERNAME }}
           mysql password: ${{ secrets.DATABASE_PASSWORD }}
+
+      - name: Set yml file
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ${{ env.RESOURCE_PATH }}
+        env:
+          spring.datasource.url: ${{ secrets.DATABASE_URL }}
+          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
+          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
+          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
+          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
+          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,18 +35,6 @@ jobs:
           mysql user: ${{ secrets.DATABASE_USERNAME }}
           mysql password: ${{ secrets.DATABASE_PASSWORD }}
 
-      - name: Set yml file
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: ${{ env.RESOURCE_PATH }}
-        env:
-          spring.datasource.url: ${{ secrets.DATABASE_URL }}
-          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
-          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
-          security.jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
-          security.oauth.kakao.client-id: ${{ secrets.REST_API_KEY }}
-          security.oauth.kakao.redirect-uri: ${{ secrets.REDIRECT_URI }}
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,9 +13,6 @@ on:
 env:
   JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
   JWT_EXPIRATION_LENGTH: ${{ secrets.JWT_EXPIRATION_LENGTH }}
-  DATABASE_URL: ${{ secrets.DATABASE_URL }}
-  DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-  DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
 jobs:
   build:
@@ -45,6 +42,10 @@ jobs:
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
 
       - name: Build and analyze
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.hibernate.orm:hibernate-spatial:6.6.0.Final'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.hibernate.orm:hibernate-spatial:6.6.0.Final'
+	implementation 'org.hibernate.orm:hibernate-spatial:6.5.2.Final'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/ku/covigator/controller/PlaceController.java
+++ b/src/main/java/com/ku/covigator/controller/PlaceController.java
@@ -1,0 +1,30 @@
+package com.ku.covigator.controller;
+
+import com.ku.covigator.domain.Place;
+import com.ku.covigator.dto.response.GetPlaceInfoResponse;
+import com.ku.covigator.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Place", description = "장소")
+@RestController
+@RequestMapping("/places")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @Operation(summary = "장소 세부 정보 조회")
+    @GetMapping
+    public ResponseEntity<GetPlaceInfoResponse> getPlaceInfo(@RequestParam String name, @RequestParam String address) {
+        Place place = placeService.getPlaceInfo(name, address);
+        return ResponseEntity.ok(GetPlaceInfoResponse.fromEntity(place));
+    }
+
+}

--- a/src/main/java/com/ku/covigator/domain/Place.java
+++ b/src/main/java/com/ku/covigator/domain/Place.java
@@ -1,0 +1,55 @@
+package com.ku.covigator.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "floor")
+    private String floor;
+
+    @Column(name = "dong_name")
+    private String dongName;
+
+    @Column(name = "building_name")
+    private String buildingName;
+
+    @Column(name = "coordinate")
+    private Point coordinate;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public Place(String name, String category, String address, String floor, String dongName, String buildingName, Point coordinate, String imageUrl) {
+        this.name = name;
+        this.category = category;
+        this.address = address;
+        this.floor = floor;
+        this.dongName = dongName;
+        this.buildingName = buildingName;
+        this.coordinate = coordinate;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/ku/covigator/dto/response/GetPlaceInfoResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetPlaceInfoResponse.java
@@ -1,0 +1,25 @@
+package com.ku.covigator.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.ku.covigator.domain.Place;
+import lombok.Builder;
+import org.locationtech.jts.geom.Geometry;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GetPlaceInfoResponse(String name, String category, String address, String floor, String dongName, String buildingName, Double latitude, Double longitude, String imageUrl) {
+    public static GetPlaceInfoResponse fromEntity(Place place) {
+        return GetPlaceInfoResponse.builder()
+                .address(place.getAddress())
+                .name(place.getName())
+                .buildingName(place.getBuildingName())
+                .latitude(place.getCoordinate().getY())
+                .longitude(place.getCoordinate().getX())
+                .floor(place.getFloor())
+                .dongName(place.getDongName())
+                .imageUrl(place.getImageUrl())
+                .category(place.getCategory())
+                .build();
+    }
+}

--- a/src/main/java/com/ku/covigator/exception/notfound/NotFoundPlaceException.java
+++ b/src/main/java/com/ku/covigator/exception/notfound/NotFoundPlaceException.java
@@ -1,0 +1,7 @@
+package com.ku.covigator.exception.notfound;
+
+public class NotFoundPlaceException extends NotFoundException{
+    public NotFoundPlaceException() {
+        super(1001, "존재하지 않는 장소입니다.");
+    }
+}

--- a/src/main/java/com/ku/covigator/repository/PlaceRepository.java
+++ b/src/main/java/com/ku/covigator/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.ku.covigator.repository;
+
+import com.ku.covigator.domain.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Optional<Place> findByNameAndAddress(String name, String address);
+}

--- a/src/main/java/com/ku/covigator/service/PlaceService.java
+++ b/src/main/java/com/ku/covigator/service/PlaceService.java
@@ -1,0 +1,20 @@
+package com.ku.covigator.service;
+
+import com.ku.covigator.domain.Place;
+import com.ku.covigator.exception.notfound.NotFoundPlaceException;
+import com.ku.covigator.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    public Place getPlaceInfo(String name, String address) {
+        return placeRepository.findByNameAndAddress(name, address)
+                .orElseThrow(NotFoundPlaceException::new);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 spring:
   datasource:
-    url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
-    username: sa
-    driver-class-name: org.h2.Driver
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,6 @@ spring:
   datasource:
     url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
     username: sa
-#    driver-class-name: com.mysql.cj.jdbc.Driver
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
@@ -12,7 +11,6 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-#        dialect: org.hibernate.dialect.MySQLDialect
 
     h2:
       console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,6 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-
-  h2:
-    console:
-      enabled: true
 
 security:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: ${DATABASE_URL}
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.h2.Driver
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -12,7 +12,11 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+#        dialect: org.hibernate.dialect.MySQLDialect
+
+    h2:
+      console:
+        enabled: true
 
 security:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
   h2:
     console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
 security:
   jwt:

--- a/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
@@ -1,0 +1,76 @@
+package com.ku.covigator.controller;
+
+import com.ku.covigator.domain.Place;
+import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
+import com.ku.covigator.security.jwt.JwtAuthInterceptor;
+import com.ku.covigator.service.PlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlaceController.class)
+class PlaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private PlaceService placeService;
+    @MockBean
+    JwtAuthInterceptor jwtAuthInterceptor;
+    @MockBean
+    JwtAuthArgumentResolver jwtAuthArgumentResolver;
+
+    @DisplayName("장소 세부 정보를 조회한다.")
+    @Test
+    void test() throws Exception {
+        //given
+        String name = "코비식당";
+        String address = "서울시 광진구";
+
+        Place place = Place.builder()
+                .name("코비식당")
+                .address("서울시 광진구")
+                .floor("1")
+                .imageUrl("")
+                .buildingName("건국대학교")
+                .dongName("자양동")
+                .coordinate(createPoint(1.0, 2.0))
+                .category("식당")
+                .build();
+
+        BDDMockito.given(placeService.getPlaceInfo(name, address)).willReturn(place);
+
+        //when //then
+        mockMvc.perform(MockMvcRequestBuilders.get("/places")
+                        .param("name", name)
+                        .param("address", address)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("코비식당"))
+                .andExpect(jsonPath("$.address").value("서울시 광진구"))
+                .andExpect(jsonPath("$.floor").value("1"))
+                .andExpect(jsonPath("$.building_name").value("건국대학교"))
+                .andExpect(jsonPath("$.dong_name").value("자양동"))
+                .andExpect(jsonPath("$.latitude").value("2.0"))
+                .andExpect(jsonPath("$.longitude").value("1.0"))
+                .andExpect(jsonPath("$.category").value("식당"));
+    }
+
+    private Point createPoint(double x, double y) {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        return geometryFactory.createPoint(new Coordinate(x, y));
+    }
+}

--- a/src/test/java/com/ku/covigator/service/PlaceServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/PlaceServiceTest.java
@@ -1,0 +1,92 @@
+package com.ku.covigator.service;
+
+import com.ku.covigator.domain.Place;
+import com.ku.covigator.exception.notfound.NotFoundPlaceException;
+import com.ku.covigator.repository.PlaceRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class PlaceServiceTest {
+
+    @Autowired
+    PlaceRepository placeRepository;
+    @Autowired
+    PlaceService placeService;
+
+    @BeforeEach
+    void tearDown() {
+        placeRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("장소를 조회한다.")
+    @Test
+    void getPlace() {
+        //given
+        String name = "코비식당";
+        String address = "서울특별시 광진구";
+
+        Place place = Place.builder()
+                .name("코비식당")
+                .address("서울특별시 광진구")
+                .floor("2")
+                .buildingName("건국대학교")
+                .category("식당")
+                .dongName("")
+                .imageUrl("")
+                .coordinate(createPoint(1.0, 2.0))
+                .build();
+
+        placeRepository.save(place);
+
+        //when
+        Place savedPlace = placeService.getPlaceInfo(name, address);
+
+        //then
+        assertThat(savedPlace.getFloor()).isEqualTo("2");
+        assertThat(savedPlace.getBuildingName()).isEqualTo("건국대학교");
+        assertThat(savedPlace.getCategory()).isEqualTo("식당");
+        assertThat(savedPlace.getCoordinate().getX()).isEqualTo(1.0);
+        assertThat(savedPlace.getCoordinate().getY()).isEqualTo(2.0);
+    }
+
+    @DisplayName("잘못된 장소 조회 시 예외가 발생한다.")
+    @Test
+    void getPlaceFailsWhenPlaceNotFound() {
+        //given
+        String name = "코비식당2";
+        String address = "서울특별시 광진구";
+
+        Place place = Place.builder()
+                .name("코비식당")
+                .address("서울특별시 광진구")
+                .floor("2")
+                .buildingName("건국대학교")
+                .category("식당")
+                .dongName("")
+                .imageUrl("")
+                .coordinate(createPoint(1.0, 2.0))
+                .build();
+
+        placeRepository.save(place);
+
+        //when //then
+        assertThatThrownBy(() -> placeService.getPlaceInfo(name, address))
+                .isInstanceOf(NotFoundPlaceException.class);
+    }
+
+    private Point createPoint(double x, double y) {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        return geometryFactory.createPoint(new Coordinate(x, y));
+    }
+
+}

--- a/src/test/java/com/ku/covigator/service/PlaceServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/PlaceServiceTest.java
@@ -3,7 +3,6 @@ package com.ku.covigator.service;
 import com.ku.covigator.domain.Place;
 import com.ku.covigator.exception.notfound.NotFoundPlaceException;
 import com.ku.covigator.repository.PlaceRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #18

## 📝 작업사항

- [X] `hibernate-spatial` 의존성 추가
- [X] 장소 조회 로직 구현

---
### hibernate-spatial과 H2
***embedded H2는 기본적으로 GIS를 지원하지 않는다!***
> DB를 MySQL로 변경하고 진행하고자 하였지만 `Github-Action`은 로컬에서 실행되는 것이 아닌 Github의 서버에서 실행되기 때문에 로컬 MySQL로 바로 접근하는 것은 불가능하다. 이를 해결하기 위해 도커를 사용하거나 RDS를 활용하여 연동할 수도 있지만 당장은 편리한 테스트를 위해 사용하지 않습니다.

***H2에서 GIS는 어떻게?***
- `hibernate-spatial` 의존성을 추가하고 H2 내장 데이터베이스를 사용한 상태로 스프링 부트를 실행하면 아래와 같은 로그를 확인할 수 있다.
![스크린샷 2024-08-28 오후 1 24 52](https://github.com/user-attachments/assets/abe67264-c4dc-4c4c-99d3-48c784bd073a)
- `hibernate-spatial adding type contributions from : org.hibernate.spatial.dialect.h2gis.H2GisDialectContributor`: `hibernate-spatial`이 `H2GisDialectContributor` 클래스를 통해 H2 데이터베이스에서 공간 데이터를 지원하기 위한 type contribution을 추가한다. 즉, H2 데이터베이스에 대해 공간 데이터 타입을 처리할 수 있는 기능이 자동으로 설정된다.