### PR TITLE
[Feat] 배포 서버에서 에러 발생 시 Slack에 알림 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ def jacocoExcludePatterns = [
 		"**/security/*",
 		"**/support/*",
 		"**/dto/*",
-		"**/*ControllerAdvice*"
+		"com/ku/covigator/controller/ControllerAdvice*"
 ]
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ def jacocoExcludePatterns = [
 		"**/security/*",
 		"**/support/*",
 		"**/dto/*",
-		"com/ku/covigator/controller/ControllerAdvice*"
+		"**/controller/ControllerAdvice"
 ]
 
 
@@ -39,7 +39,7 @@ sonar {
 		property 'sonar.sources', 'src'
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**'
+		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**, **/controller/ControllerAdvice'
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'
 		property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ def jacocoExcludePatterns = [
 		"**/exception/*",
 		"**/security/*",
 		"**/support/*",
-		"**/dto/*"
+		"**/dto/*",
+		"**/controller/ControllerAdvice"
 ]
 
 
@@ -80,6 +81,9 @@ dependencies {
 
 	//spring-security-crypto
 	implementation 'org.springframework.security:spring-security-crypto'
+
+	//slack api client
+	implementation 'com.slack.api:slack-api-client:1.42.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ def jacocoExcludePatterns = [
 		"**/security/*",
 		"**/support/*",
 		"**/dto/*",
-		"**/controller/ControllerAdvice"
+		"**/*ControllerAdvice*"
 ]
 
 
@@ -39,7 +39,7 @@ sonar {
 		property 'sonar.sources', 'src'
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**, **/controller/ControllerAdvice'
+		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**, **/*ControllerAdvice*'
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'
 		property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ def jacocoExcludePatterns = [
 		"**/security/*",
 		"**/support/*",
 		"**/dto/*",
-		"**/controller/ControllerAdvice"
+		"**/*ControllerAdvice*"
 ]
 
 

--- a/src/main/java/com/ku/covigator/config/AsyncConfig.java
+++ b/src/main/java/com/ku/covigator/config/AsyncConfig.java
@@ -1,9 +1,33 @@
 package com.ku.covigator.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
+
+    private static final int CORE_POOL_SIZE = 30;
+    private static final int MAX_POOL_SIZE = 50;
+    private static final int QUEUE_CAPACITY = 100;
+    private static final boolean WAIT_TASK_COMPLETE = true;
+    private static final int AWAIT_TERMINATION_SECONDS = 30;
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(CORE_POOL_SIZE);
+        taskExecutor.setMaxPoolSize(MAX_POOL_SIZE);
+        taskExecutor.setQueueCapacity(QUEUE_CAPACITY);
+        taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        taskExecutor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETE);
+        taskExecutor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
 }

--- a/src/main/java/com/ku/covigator/config/AsyncConfig.java
+++ b/src/main/java/com/ku/covigator/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.ku.covigator.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/ku/covigator/config/properties/SlackProperties.java
+++ b/src/main/java/com/ku/covigator/config/properties/SlackProperties.java
@@ -1,0 +1,12 @@
+package com.ku.covigator.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties("slack.webhook.url")
+public final class SlackProperties {
+    private final String slackWebhookUrl;
+}

--- a/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
+++ b/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
@@ -2,12 +2,18 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.response.ErrorResponse;
 import com.ku.covigator.exception.CovigatorException;
+import com.ku.covigator.support.SlackAlarmGenerator;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ControllerAdvice {
+
+    private final SlackAlarmGenerator slackAlarmGenerator;
 
     @ExceptionHandler(CovigatorException.class)
     public ResponseEntity<ErrorResponse> handleCovigatorException(CovigatorException e) {
@@ -15,7 +21,8 @@ public class ControllerAdvice {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleInternalException() {
+    public ResponseEntity<ErrorResponse> handleInternalException(Exception e, HttpServletRequest request) {
+        slackAlarmGenerator.sendSlackAlertErrorLog(e, request);
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(9999, "서버 복구중입니다. 잠시만 기다려주세요."));
     }

--- a/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
+++ b/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.ku.covigator.controller;
+
+import com.ku.covigator.dto.response.ErrorResponse;
+import com.ku.covigator.exception.CovigatorException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(CovigatorException.class)
+    public ResponseEntity<ErrorResponse> handleCovigatorException(CovigatorException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternalException() {
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse(9999, "서버 복구중입니다. 잠시만 기다려주세요."));
+    }
+
+}

--- a/src/main/java/com/ku/covigator/dto/response/ErrorResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.ku.covigator.dto.response;
+
+public record ErrorResponse (int code, String message){
+}

--- a/src/main/java/com/ku/covigator/support/SlackAlarmGenerator.java
+++ b/src/main/java/com/ku/covigator/support/SlackAlarmGenerator.java
@@ -1,0 +1,67 @@
+package com.ku.covigator.support;
+
+import com.ku.covigator.config.properties.SlackProperties;
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+@Slf4j
+@Component
+@EnableConfigurationProperties(SlackProperties.class)
+@RequiredArgsConstructor
+public class SlackAlarmGenerator {
+
+    private final SlackProperties slackProperties;
+    private final Slack slack = Slack.getInstance();
+
+    @Async
+    public void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
+        try {
+            slack.send(slackProperties.getSlackWebhookUrl(), payload(p -> p
+                    .text("[서버 에러 발생]")
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request))
+                    )
+            ));
+        } catch (IOException slackError) {
+            log.error("Slack 통신 예외 발생");
+        }
+    }
+
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + " 발생 에러 로그")
+                .fields(List.of(
+                                generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                                generateSlackField("Request URL", request.getRequestURL() + " " + request.getMethod()),
+                                generateSlackField("Error Message", e.getMessage())
+                        )
+                )
+                .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,7 @@ security:
 springdoc:
   swagger-ui:
     path: "/api-doc"
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan("com.ku.covigator.support")
 @WebMvcTest(controllers = AuthController.class)
 class AuthControllerTest {
 

--- a/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan("com.ku.covigator.support")
 @WebMvcTest(controllers = CourseController.class)
 class CourseControllerTest {
 

--- a/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan("com.ku.covigator.support")
 @WebMvcTest(controllers = PlaceController.class)
 class PlaceControllerTest {
 

--- a/src/test/java/com/ku/covigator/controller/ReviewControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/ReviewControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan("com.ku.covigator.support")
 @WebMvcTest(controllers = ReviewController.class)
 class ReviewControllerTest {
 

--- a/src/test/java/com/ku/covigator/controller/TravelStyleControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/TravelStyleControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan("com.ku.covigator.support")
 @WebMvcTest(controllers = TravelStyleController.class)
 class TravelStyleControllerTest {
 


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #28 

## 📝 작업사항

- [x] 에러 핸들링 ControllerAdvice 구현
- [x] 스프링-Slack 연동
- [x] 에러 메시지 전송 `@Async`로 비동기 처리

## 📌 비동기 처리 이유

- Slack 메시지 전송은 제어할 수 있는 부분이 아니다. 만약 Slack 서버에 지연이 생겨 전송이 늦는다면 가장 중요한 프로세스인 `클라이언트 응답`이 제대로 수행되지 않게 될 수 있다. 
 
***따라서 Slack 메시지 전송 로직을 비동기로 처리하여 클라이언트에게 응답을 제공하는 부분에 지연이 생기지 않도록 처리한다.***

- 스레드 풀 방식을 사용하도록 `TaskExecutor` 사용