### PR TITLE
[Feat] 프로필 이미지 업로드 로직 구현 (with AWS S3)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        env:
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -41,8 +41,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY: ${{ secrets.ACCESS_KEY_ID }}
+          AWS_SECRET_KEY: ${{ secrets.ACCESS_KEY_SECRET }}
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,15 @@ dependencies {
 
 	//slack api client
 	implementation 'com.slack.api:slack-api-client:1.42.0'
+
+	//aws
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
+	//s3-mock
+	testImplementation 'io.findify:s3mock_2.13:0.2.6'
+
+	//websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -149,3 +149,9 @@ jacocoTestCoverageVerification {
 		}
 	}
 }
+
+test {
+	testLogging {
+		exceptionFormat = 'full'
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -149,9 +149,3 @@ jacocoTestCoverageVerification {
 		}
 	}
 }
-
-test {
-	testLogging {
-		exceptionFormat = 'full'
-	}
-}

--- a/src/main/java/com/ku/covigator/config/S3Config.java
+++ b/src/main/java/com/ku/covigator/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.ku.covigator.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.ku.covigator.config.properties.AwsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(AwsProperties.class)
+public class S3Config {
+
+    private final AwsProperties awsProperties;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(awsProperties.getAccessKey(), awsProperties.getSecretKey());
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(awsProperties.getRegion())
+                .build();
+    }
+}

--- a/src/main/java/com/ku/covigator/config/properties/AwsProperties.java
+++ b/src/main/java/com/ku/covigator/config/properties/AwsProperties.java
@@ -1,0 +1,14 @@
+package com.ku.covigator.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties("aws")
+public class AwsProperties {
+    private final String accessKey;
+    private final String secretKey;
+    private final String region;
+}

--- a/src/main/java/com/ku/covigator/config/properties/S3Properties.java
+++ b/src/main/java/com/ku/covigator/config/properties/S3Properties.java
@@ -1,0 +1,12 @@
+package com.ku.covigator.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties("aws.s3")
+public class S3Properties {
+    private final String bucket;
+}

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Auth", description = "인증/인가")
 @RestController
@@ -28,8 +29,9 @@ public class AuthController {
 
     @Operation(summary = "회원가입")
     @PostMapping("/sign-up")
-    public ResponseEntity<AccessTokenResponse> signUp(@RequestBody PostSignUpRequest request) {
-        String accessToken = authService.signUp(request.toEntity());
+    public ResponseEntity<AccessTokenResponse> signUp(@RequestPart(value = "postSignUpRequest") PostSignUpRequest request,
+                                                      @RequestPart(value = "image") MultipartFile image) {
+        String accessToken = authService.signUp(request.toEntity(), image);
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
     }
 

--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -70,4 +70,8 @@ public class Member extends BaseTime {
     public void updateTravelStyle(TravelStyle newTravelStyle) {
         this.travelStyle.patchTravelStyle(newTravelStyle);
     }
+
+    public void addImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/ku/covigator/service/S3Service.java
+++ b/src/main/java/com/ku/covigator/service/S3Service.java
@@ -1,0 +1,59 @@
+package com.ku.covigator.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ku.covigator.config.properties.S3Properties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@EnableConfigurationProperties(S3Properties.class)
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3Client s3Client;
+    private final S3Properties s3Properties;
+    private final static String PROFILE_IMAGE_BASE_DIRECTORY = "profile-image/";
+
+    public String uploadImage(MultipartFile multipartFile) {
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+        String fileName = createFileName(multipartFile.getOriginalFilename());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            s3Client.putObject(
+                    new PutObjectRequest(s3Properties.getBucket(), fileName, inputStream, objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        } catch (IOException e) {
+            log.error("S3 파일 업로드에 실패했습니다. {}", e.getMessage());
+        }
+
+        return s3Client.getUrl(s3Properties.getBucket(), fileName).toString();
+    }
+
+//    public void deleteImage(String fileName) {
+//        s3Client.deleteObject(
+//                new DeleteObjectRequest(s3Properties.getBucket(), fileName)
+//        );
+//    }
+
+    private String createFileName(String fileName) {
+
+        String uniqueID = '$' + UUID.randomUUID().toString();
+        return PROFILE_IMAGE_BASE_DIRECTORY + fileName.concat(uniqueID);
+    }
+
+}

--- a/src/main/java/com/ku/covigator/service/S3Service.java
+++ b/src/main/java/com/ku/covigator/service/S3Service.java
@@ -23,7 +23,7 @@ public class S3Service {
 
     private final AmazonS3Client s3Client;
     private final S3Properties s3Properties;
-    private final static String PROFILE_IMAGE_BASE_DIRECTORY = "profile-image/";
+    private static final String PROFILE_IMAGE_BASE_DIRECTORY = "profile-image/";
 
     public String uploadImage(MultipartFile multipartFile) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=LIKE
+    url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
     username: sa
     driver-class-name: org.h2.Driver
   jpa:
@@ -11,10 +11,13 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-
   h2:
     console:
       enabled: true
+  servlet:
+    multipart:
+      max-request-size: 5MB
+      max-file-size: 10MB
 
 security:
   jwt:
@@ -34,3 +37,10 @@ springdoc:
 slack:
   webhook:
     url: ${SLACK_WEBHOOK_URL}
+
+aws:
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  region: us-east-1
+  s3:
+    bucket: ${S3_BUCKET_NAME}

--- a/src/test/java/com/ku/covigator/config/MockS3Config.java
+++ b/src/test/java/com/ku/covigator/config/MockS3Config.java
@@ -1,0 +1,47 @@
+package com.ku.covigator.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.ku.covigator.config.properties.AwsProperties;
+import com.ku.covigator.config.properties.S3Properties;
+import io.findify.s3mock.S3Mock;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+@EnableConfigurationProperties(AwsProperties.class)
+public class MockS3Config {
+
+    private final AwsProperties awsProperties;
+    private final S3Properties s3Properties;
+
+    public MockS3Config(AwsProperties awsProperties, S3Properties s3Properties) {
+        this.awsProperties = awsProperties;
+        this.s3Properties = s3Properties;
+    }
+
+    @Bean
+    public S3Mock s3Mock() {
+        return new S3Mock.Builder().withPort(8080).withInMemoryBackend().build();
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(S3Mock s3Mock) {
+
+        s3Mock.start();
+        AwsClientBuilder.EndpointConfiguration endpoint =
+                new AwsClientBuilder.EndpointConfiguration("http://localhost:8080", awsProperties.getRegion());
+        AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+        client.createBucket(s3Properties.getBucket());
+        return client;
+    }
+}

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -14,11 +14,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -69,12 +69,24 @@ class AuthControllerTest {
                 .imageUrl("covigator123")
                 .build();
 
-        given(authService.signUp(any())).willReturn("token");
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+
+        MockMultipartFile jsonRequest = new MockMultipartFile(
+                "postSignUpRequest",
+                null,
+                "application/json",
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        given(authService.signUp(any(), any())).willReturn("token");
 
         //when //then
-        mockMvc.perform(post("/accounts/sign-up")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(multipart("/accounts/sign-up")
+                        .file(imageFile)
+                        .file(jsonRequest)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
                 )
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/ku/covigator/domain/member/MemberTest.java
+++ b/src/test/java/com/ku/covigator/domain/member/MemberTest.java
@@ -91,4 +91,21 @@ class MemberTest {
         assertThat(member.getTravelStyle().getActivityType()).isEqualTo(ActivityType.ACTIVITY);
     }
 
+    @DisplayName("프로필 이미지를 추가한다.")
+    @Test
+    void addImageUrl() {
+        //given
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password("covigator123")
+                .nickname("covi")
+                .platform(Platform.LOCAL)
+                .build();
+
+        //when
+        member.addImageUrl("www.covi.com");
+
+        //then
+        assertThat(member.getImageUrl()).isEqualTo("www.covi.com");
+    }
 }

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -118,7 +118,7 @@ class AuthServiceTest {
 
     @DisplayName("로컬 회원 가입 시 같은 플랫폼에 대한 중복 회원이 아닌 경우 정상적으로 회원 가입 되어 토큰을 반환한다.")
     @Test
-    void signUpLocalSuccessIfThereIsNoDuplicateMember() throws IOException {
+    void signUpLocalSuccessIfThereIsNoDuplicateMember() {
         //given
         Member member = Member.builder()
                 .email("covi@naver.com")

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -21,8 +21,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -13,10 +13,15 @@ import com.ku.covigator.security.kakao.KakaoOauthProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -35,6 +40,8 @@ class AuthServiceTest {
     JwtProvider jwtProvider;
     @MockBean
     KakaoOauthProvider kakaoOauthProvider;
+    @MockBean
+    S3Service s3Service;
 
     @AfterEach
     void tearDown() {
@@ -111,7 +118,7 @@ class AuthServiceTest {
 
     @DisplayName("로컬 회원 가입 시 같은 플랫폼에 대한 중복 회원이 아닌 경우 정상적으로 회원 가입 되어 토큰을 반환한다.")
     @Test
-    void signUpLocalSuccessIfThereIsNoDuplicateMember() {
+    void signUpLocalSuccessIfThereIsNoDuplicateMember() throws IOException {
         //given
         Member member = Member.builder()
                 .email("covi@naver.com")
@@ -121,8 +128,14 @@ class AuthServiceTest {
                 .platform(Platform.LOCAL)
                 .build();
 
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+                .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
+
         //when
-        String accessToken = authService.signUp(member);
+        String accessToken = authService.signUp(member, imageFile);
         Long savedMemberId = Long.parseLong(jwtProvider.getPrincipal(accessToken));
 
         //then
@@ -151,8 +164,14 @@ class AuthServiceTest {
 
         memberRepository.save(member);
 
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+                .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
+
         //when //then
-        assertThatThrownBy(() -> authService.signUp(newMember))
+        assertThatThrownBy(() -> authService.signUp(newMember, imageFile))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("이미 가입된 사용자입니다.");
     }
@@ -179,8 +198,14 @@ class AuthServiceTest {
 
         memberRepository.save(member);
 
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+                .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
+
         //when // then
-        assertDoesNotThrow(() -> authService.signUp(newMember));
+        assertDoesNotThrow(() -> authService.signUp(newMember, imageFile));
     }
 
     @DisplayName("로컬 회원 가입 시 비밀번호는 암호화되어 저장된다.")
@@ -196,8 +221,14 @@ class AuthServiceTest {
                 .platform(Platform.LOCAL)
                 .build();
 
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+                .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
+
         //when
-        authService.signUp(member);
+        authService.signUp(member, imageFile);
 
         // then
         assertThat(member.getPassword()).isNotEqualTo(password);

--- a/src/test/java/com/ku/covigator/service/S3ServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/S3ServiceTest.java
@@ -1,0 +1,44 @@
+package com.ku.covigator.service;
+
+import com.ku.covigator.config.MockS3Config;
+import io.findify.s3mock.S3Mock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Import(MockS3Config.class)
+@SpringBootTest
+class S3ServiceTest {
+
+    @Autowired
+    private S3Mock s3Mock;
+    @Autowired
+    private S3Service s3Service;
+
+    @AfterEach
+    public void tearDown() {
+        s3Mock.stop();
+    }
+
+    @DisplayName("s3 버킷에 이미지를 업로드한다.")
+    @Test
+    void uploadImage() {
+        //given
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+
+        //when
+        String uploadedImageUrl = s3Service.uploadImage(imageFile);
+
+        //then
+        assertThat(uploadedImageUrl).contains("test-image.jpg");
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #43 

## 📝 작업사항

- [x] 프로필 이미지 업로드 로직 구현
- [x] S3 버킷 생성 및 연동
- [x] S3 테스트 코드 작성

## 참고사항

✅ 로컬 회원 가입 요청시 회원 정보가 담긴 `DTO`와 회원 이미지 파일이 담긴 `MultipartFile`을 모두 받아야 한다.
- 기존에는 DTO를 application/json 형식으로 Request Body에 담아 요청함. 
- 하지만 MultipartFile은 `multipart/form-data`로 받아야 하기 때문에 동시에 받을 수 없는 문제가 발생함. 
- HTTP request body에 multipart/form-data 가 포함되어 있는 경우 `@RequestPart`를 사용
- 따라서 `DTO`와 `MultipartFile` 모두 `@RequestPart`를 사용하여 받는다. 요청은 하단 스크린샷 이미지와 같은 형식으로 요청한다.

<img width="809" alt="스크린샷 2024-09-19 오후 2 33 24" src="https://github.com/user-attachments/assets/6bf358db-d11f-4a6f-984d-d6b8b169ba94">

<br>
<br>

✅ S3 업로드 파일 생성
- 중복된 이름의 파일이 S3 버킷에 존재하는 경우 예기치 못한 에러를 발생시킬 수 있다. 따라서 이를 방지하고자 S3에 업로드 하기 이전에 랜덤한 값을 생성하여 파일 이름 뒤에 붙인 후 업로드 할 수 있도록 한다.

✅ S3서비스 테스트코드 작성

- `@TestConfiguration`을 사용하여 테스트용 `S3Config` 클래스를 생성한다. 생성된 테스트용 설정 클래스는 `@Import`를 사용하여 S3서비스 테스트 클래스에 적용한다.
- MultipartFile을 mocking 하기 위해 `MockMultipartFile` 객체를 생성하여 사용한다.