### PR TITLE
[Fix] slack webhook url 이 정상적으로 주입되지 않고 있던 문제 해결

### DIFF
--- a/src/main/java/com/ku/covigator/config/SwaggerConfig.java
+++ b/src/main/java/com/ku/covigator/config/SwaggerConfig.java
@@ -33,7 +33,6 @@ public class SwaggerConfig {
         );
 
         return new OpenAPI()
-                .components(new Components())
                 .addSecurityItem(securityRequirement)
                 .components(components);
 

--- a/src/main/java/com/ku/covigator/config/properties/SlackProperties.java
+++ b/src/main/java/com/ku/covigator/config/properties/SlackProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Getter
 @RequiredArgsConstructor
-@ConfigurationProperties("slack.webhook.url")
+@ConfigurationProperties("slack.webhook")
 public final class SlackProperties {
-    private final String slackWebhookUrl;
+    private final String url;
 }

--- a/src/main/java/com/ku/covigator/support/SlackAlarmGenerator.java
+++ b/src/main/java/com/ku/covigator/support/SlackAlarmGenerator.java
@@ -30,7 +30,7 @@ public class SlackAlarmGenerator {
     @Async
     public void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
         try {
-            slack.send(slackProperties.getSlackWebhookUrl(), payload(p -> p
+            slack.send(slackProperties.getUrl(), payload(p -> p
                     .text("[서버 에러 발생]")
                     .attachments(
                             List.of(generateSlackAttachment(e, request))


### PR DESCRIPTION
## 📝 작업사항

- [x] `SlackProperties` 클래스 수정
- [x] 알림 동작 확인 