### PR TITLE
[Feat] 커뮤니티 코스-장소 이미지 로직 추가 및 코스-장소 관련 DTO에서 장소 이미지 url을 반환하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'io.rest-assured:rest-assured'
 
 	//jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.5'

--- a/src/main/java/com/ku/covigator/controller/CourseController.java
+++ b/src/main/java/com/ku/covigator/controller/CourseController.java
@@ -16,6 +16,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "course", description = "커뮤니티 코스")
 @RestController
@@ -26,8 +29,10 @@ public class CourseController {
 
     @Operation(summary = "코스 등록")
     @PostMapping("/community/courses")
-    public ResponseEntity<Void> addCommunityCourse(@LoggedInMemberId Long memberId, @RequestBody PostCourseRequest request) {
-        courseService.addCommunityCourse(memberId, request);
+    public ResponseEntity<Void> addCommunityCourse(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
+                                                   @RequestPart(value = "postCourseRequest") PostCourseRequest request,
+                                                   @RequestPart(value = "image") List<MultipartFile> images) {
+        courseService.addCommunityCourse(memberId, request, images);
         return ResponseEntity.ok().build();
     }
 
@@ -35,7 +40,7 @@ public class CourseController {
     @GetMapping("/community/courses")
     public ResponseEntity<GetCommunityCourseListResponse> getAllCommunityCourses(
 
-            @LoggedInMemberId Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
 
             @Parameter(description = "페이지 번호 (0부터 시작)", schema = @Schema(defaultValue = "0"))
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -53,7 +58,7 @@ public class CourseController {
     @Operation(summary = "상세 코스 조회")
     @GetMapping("/community/courses/{course_id}")
     public ResponseEntity<GetCommunityCourseInfoResponse> getCommunityCourseInfo(
-            @LoggedInMemberId Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @PathVariable(name = "course_id") Long courseId) {
         return ResponseEntity.ok(courseService.findCourse(memberId, courseId));
     }
@@ -68,13 +73,13 @@ public class CourseController {
 
     @Operation(summary = "찜한 코스 모아보기")
     @GetMapping("/my-page/dibs-courses")
-    public ResponseEntity<GetCourseListResponse> getLikedCourses(@LoggedInMemberId Long memberId){
+    public ResponseEntity<GetCourseListResponse> getLikedCourses(@Parameter(hidden = true) @LoggedInMemberId Long memberId){
         return ResponseEntity.ok(courseService.findLikedCourses(memberId));
     }
 
     @Operation(summary = "마이 코스 모아보기")
     @GetMapping("/my-page/my-courses")
-    public ResponseEntity<GetCourseListResponse> getMyCourses(@LoggedInMemberId Long memberId) {
+    public ResponseEntity<GetCourseListResponse> getMyCourses(@Parameter(hidden = true) @LoggedInMemberId Long memberId) {
         return ResponseEntity.ok(courseService.findMyCourses(memberId));
     }
 }

--- a/src/main/java/com/ku/covigator/controller/DibsController.java
+++ b/src/main/java/com/ku/covigator/controller/DibsController.java
@@ -3,6 +3,7 @@ package com.ku.covigator.controller;
 import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.DibsService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class DibsController {
     @Operation(summary = "좋아요(찜) 등록")
     @PostMapping("/community/courses/{course_id}/dibs")
     public ResponseEntity<Void> likeCourse(
-            @LoggedInMemberId Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @PathVariable(name = "course_id") Long courseId) {
         dibsService.addLike(memberId, courseId);
         return ResponseEntity.ok().build();
@@ -30,7 +31,7 @@ public class DibsController {
     @Operation(summary = "좋아요(찜) 해제")
     @DeleteMapping("/community/courses/{course_id}/dibs")
     public ResponseEntity<Void> deleteCourseLiked(
-            @LoggedInMemberId Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @PathVariable(name = "course_id") Long courseId) {
         dibsService.deleteLike(memberId, courseId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/ku/covigator/controller/ReviewController.java
+++ b/src/main/java/com/ku/covigator/controller/ReviewController.java
@@ -25,7 +25,7 @@ public class ReviewController {
     @Operation(summary = "리뷰 등록")
     @PostMapping
     public ResponseEntity<Void> addReview(
-            @LoggedInMemberId Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @PathVariable(name = "course_id") Long courseId,
             @RequestBody PostReviewRequest request) {
         reviewService.addReview(memberId, courseId, request);

--- a/src/main/java/com/ku/covigator/controller/TravelStyleController.java
+++ b/src/main/java/com/ku/covigator/controller/TravelStyleController.java
@@ -5,6 +5,7 @@ import com.ku.covigator.dto.request.PostTravelStyleRequest;
 import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.TravelStyleService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class TravelStyleController {
 
     @Operation(summary = "여행 스타일 저장")
     @PostMapping
-    public ResponseEntity<Void> saveTravelStyle(@LoggedInMemberId Long memberId,
+    public ResponseEntity<Void> saveTravelStyle(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
                                                 @RequestBody PostTravelStyleRequest request) {
         travelStyleService.saveTravelStyle(memberId, request.toEntity());
         return ResponseEntity.ok().build();
@@ -28,7 +29,7 @@ public class TravelStyleController {
 
     @Operation(summary = "여행 스타일 수정")
     @PatchMapping
-    public ResponseEntity<Void> patchTravelStyle(@LoggedInMemberId Long memberId,
+    public ResponseEntity<Void> patchTravelStyle(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
                                                  @RequestBody PatchTravelStyleRequest request) {
         travelStyleService.updateTravelStyle(memberId, request.toEntity());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/ku/covigator/domain/Course.java
+++ b/src/main/java/com/ku/covigator/domain/Course.java
@@ -81,4 +81,8 @@ public class Course extends BaseTime {
         return this.places.get(0).getImageUrl();
     }
 
+    public void addPlace(CoursePlace place) {
+        this.places.add(place);
+    }
+
 }

--- a/src/main/java/com/ku/covigator/domain/Course.java
+++ b/src/main/java/com/ku/covigator/domain/Course.java
@@ -75,4 +75,10 @@ public class Course extends BaseTime {
         this.dibsCnt -= 1;
     }
 
+    public String getThumbnailImage() {
+
+        if(this.places.isEmpty()) return null;
+        return this.places.get(0).getImageUrl();
+    }
+
 }

--- a/src/main/java/com/ku/covigator/domain/CoursePlace.java
+++ b/src/main/java/com/ku/covigator/domain/CoursePlace.java
@@ -1,6 +1,5 @@
 package com.ku.covigator.domain;
 
-import com.ku.covigator.domain.Course;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -31,17 +30,25 @@ public class CoursePlace {
     @Column(name = "address")
     private String address;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", referencedColumnName = "id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Course course;
 
     @Builder
-    public CoursePlace(String name, String description, String category, String address, Course course) {
+    public CoursePlace(String name, String description, String category, String address, Course course, String imageUrl) {
         this.name = name;
         this.description = description;
         this.category = category;
         this.address = address;
         this.course = course;
+        this.imageUrl = imageUrl;
+    }
+
+    public void addImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseInfoResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseInfoResponse.java
@@ -14,7 +14,7 @@ public record GetCommunityCourseInfoResponse(Long courseId, String courseName, S
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record PlaceDto(Long placeId, String placeName, String placeDescription, String category) {
+    public record PlaceDto(Long placeId, String placeName, String placeDescription, String category, String imageUrl) {
     }
 
     public static GetCommunityCourseInfoResponse from(Course course, boolean dibs) {
@@ -24,6 +24,7 @@ public record GetCommunityCourseInfoResponse(Long courseId, String courseName, S
                         .placeDescription(place.getDescription())
                         .placeName(place.getName())
                         .category(place.getCategory())
+                        .imageUrl(place.getImageUrl())
                         .build()
                 ).toList();
         return GetCommunityCourseInfoResponse.builder()

--- a/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseListResponse.java
@@ -16,7 +16,7 @@ public record GetCommunityCourseListResponse(List<CourseDto> courses, Boolean ha
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record CourseDto(Long courseId, String name, String description, Double score, Boolean dibs) {
+    public record CourseDto(Long courseId, String name, String description, Double score, Boolean dibs, String imageUrl) {
     }
 
     public static GetCommunityCourseListResponse from(Slice<Course> courseSlice, Set<Long> dibsCourseId) {
@@ -27,6 +27,7 @@ public record GetCommunityCourseListResponse(List<CourseDto> courses, Boolean ha
                         .description(course.getDescription())
                         .score(course.getAvgScore())
                         .dibs(dibsCourseId.contains(course.getId())) // 좋아요 여부 판단
+                        .imageUrl(course.getThumbnailImage())
                         .build()
                 ).collect(Collectors.toList());
 

--- a/src/main/java/com/ku/covigator/dto/response/GetCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCourseListResponse.java
@@ -13,7 +13,7 @@ import java.util.List;
 public record GetCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
 
     @Builder
-    public record CourseDto(String name, String description, Double score) {
+    public record CourseDto(Long courseId, String name, String description, Double score, String imageUrl) {
     }
 
     public static GetCourseListResponse fromCourseSlice(Slice<Course> courseSlice) {
@@ -22,6 +22,8 @@ public record GetCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
                         .name(course.getName())
                         .description(course.getDescription())
                         .score(course.getAvgScore())
+                        .courseId(course.getId())
+                        .imageUrl(course.getThumbnailImage())
                         .build()
                 ).toList();
         return GetCourseListResponse.builder()

--- a/src/main/java/com/ku/covigator/dto/response/GetCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCourseListResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 public record GetCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
 
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record CourseDto(Long courseId, String name, String description, Double score, String imageUrl) {
     }
 

--- a/src/main/java/com/ku/covigator/dto/response/GetReviewResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetReviewResponse.java
@@ -12,7 +12,8 @@ import java.util.List;
 public record GetReviewResponse(List<ReviewDto> reviews, Boolean hasNext) {
 
     @Builder
-    public record ReviewDto(String author, Integer score, String comment) {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record ReviewDto(String author, Integer score, String comment, String profileImageUrl) {
 
     }
 
@@ -22,6 +23,7 @@ public record GetReviewResponse(List<ReviewDto> reviews, Boolean hasNext) {
                         .author(review.getMember().getNickname())
                         .comment(review.getComment())
                         .score(review.getScore())
+                        .profileImageUrl(review.getMember().getImageUrl())
                         .build()
         ).toList();
         return new GetReviewResponse(reviewDtos, reviews.hasNext());

--- a/src/main/java/com/ku/covigator/repository/CourseRepository.java
+++ b/src/main/java/com/ku/covigator/repository/CourseRepository.java
@@ -20,11 +20,12 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("""
     SELECT c
     FROM Course c, Dibs d
+    LEFT JOIN FETCH c.places p
     WHERE d.member.id = :memberId AND d.course.id = c.id
     ORDER BY d.createdAt DESC
     """)
     Slice<Course> findLikedCoursesByMemberId(Long memberId, Pageable pageable);
 
-    @EntityGraph(attributePaths = "member")
+    @EntityGraph(attributePaths = {"member", "places"})
     Slice<Course> findMyCoursesByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/ku/covigator/repository/CourseRepository.java
+++ b/src/main/java/com/ku/covigator/repository/CourseRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
+    @EntityGraph(attributePaths = "places")
     Slice<Course> findAllCoursesByIsPublic(Pageable pageable, Character isPublic);
 
     @EntityGraph(attributePaths = "places")

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
 
         // S3에 프로필 이미지 업로드
         if(image != null && !image.isEmpty()) {
-            String uploadedImageUrl = s3Service.uploadImage(image);
+            String uploadedImageUrl = s3Service.uploadImage(image, "profile");
             member.addImageUrl(uploadedImageUrl);
         }
 

--- a/src/main/java/com/ku/covigator/service/CourseService.java
+++ b/src/main/java/com/ku/covigator/service/CourseService.java
@@ -71,6 +71,7 @@ public class CourseService {
         return GetCommunityCourseListResponse.from(courses, dibsCourseId);
     }
 
+    @Transactional(readOnly = true)
     public GetCourseListResponse findLikedCourses(Long memberId) {
 
         Pageable pageable = PageRequest.of(0, 10);
@@ -78,6 +79,7 @@ public class CourseService {
         return GetCourseListResponse.fromCourseSlice(courses);
     }
 
+    @Transactional(readOnly = true)
     public GetCourseListResponse findMyCourses(Long memberId) {
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());

--- a/src/main/java/com/ku/covigator/service/S3Service.java
+++ b/src/main/java/com/ku/covigator/service/S3Service.java
@@ -24,13 +24,15 @@ public class S3Service {
     private final AmazonS3Client s3Client;
     private final S3Properties s3Properties;
     private static final String PROFILE_IMAGE_BASE_DIRECTORY = "profile-image/";
+    private static final String PLACE_IMAGE_BASE_DIRECTORY = "place-image/";
+    private static final String PROFILE = "profile";
 
-    public String uploadImage(MultipartFile multipartFile) {
+    public String uploadImage(MultipartFile multipartFile, String imageType) {
 
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(multipartFile.getSize());
         objectMetadata.setContentType(multipartFile.getContentType());
-        String fileName = createFileName(multipartFile.getOriginalFilename());
+        String fileName = createFileName(multipartFile.getOriginalFilename(), imageType);
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             s3Client.putObject(
@@ -50,10 +52,16 @@ public class S3Service {
 //        );
 //    }
 
-    private String createFileName(String fileName) {
+    private String createFileName(String fileName, String imageType) {
 
         String uniqueID = '$' + UUID.randomUUID().toString();
-        return PROFILE_IMAGE_BASE_DIRECTORY + fileName.concat(uniqueID);
+
+        if(imageType.equals(PROFILE)){
+            return PROFILE_IMAGE_BASE_DIRECTORY + fileName.concat(uniqueID);
+        }
+
+        return PLACE_IMAGE_BASE_DIRECTORY + fileName.concat(uniqueID);
+
     }
 
 }

--- a/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -68,10 +69,26 @@ class CourseControllerTest {
                 .places(List.of(placeDto, placeDto2))
                 .build();
 
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+        MockMultipartFile imageFile2 = new MockMultipartFile(
+                "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
+        );
+
+        MockMultipartFile jsonRequest = new MockMultipartFile(
+                "postCourseRequest",
+                null,
+                "application/json",
+                objectMapper.writeValueAsBytes(postCourseRequest)
+        );
+
         //when //then
-        mockMvc.perform(post("/community/courses")
-                        .content(objectMapper.writeValueAsString(postCourseRequest))
-                        .contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(multipart("/community/courses")
+                        .file(imageFile)
+                        .file(imageFile2)
+                        .file(jsonRequest)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
                 ).andDo(print())
                 .andExpect(status().isOk());
     }
@@ -88,6 +105,7 @@ class CourseControllerTest {
                 .description("건대 핫플 요약 코스")
                 .score(5.0)
                 .dibs(true)
+                .imageUrl("www.imageUrl.com")
                 .build();
 
         GetCommunityCourseListResponse.CourseDto courseDto2 = GetCommunityCourseListResponse.CourseDto.builder()
@@ -96,6 +114,7 @@ class CourseControllerTest {
                 .description("건대 핫플 요약 코스2")
                 .score(0.0)
                 .dibs(false)
+                .imageUrl("www.imageUrl2.com")
                 .build();
 
         GetCommunityCourseListResponse response = GetCommunityCourseListResponse.builder()
@@ -124,11 +143,13 @@ class CourseControllerTest {
                         jsonPath("$.courses[0].description").value("건대 핫플 요약 코스"),
                         jsonPath("$.courses[0].score").value(5.0),
                         jsonPath("$.courses[0].dibs").value(true),
+                        jsonPath("$.courses[0].image_url").value("www.imageUrl.com"),
                         jsonPath("$.courses[1].course_id").value(2L),
                         jsonPath("$.courses[1].name").value("건대 풀코스2"),
                         jsonPath("$.courses[1].description").value("건대 핫플 요약 코스2"),
                         jsonPath("$.courses[1].score").value(0.0),
                         jsonPath("$.courses[1].dibs").value(false),
+                        jsonPath("$.courses[1].image_url").value("www.imageUrl2.com"),
                         jsonPath("$.has_next").value(false)
                 );
     }
@@ -143,7 +164,9 @@ class CourseControllerTest {
         GetCommunityCourseInfoResponse.PlaceDto placeDto = GetCommunityCourseInfoResponse.PlaceDto.builder()
                 .placeName("가츠시")
                 .placeDescription("공대생 추천 맛집")
-                .category("식당").build();
+                .imageUrl("www.image.com")
+                .category("식당")
+                .build();
 
         GetCommunityCourseInfoResponse response = GetCommunityCourseInfoResponse.builder()
                 .courseName("건대 풀코스")
@@ -169,7 +192,8 @@ class CourseControllerTest {
                         jsonPath("$.dibs").value(true),
                         jsonPath("$.places[0].place_name").value("가츠시"),
                         jsonPath("$.places[0].place_description").value("공대생 추천 맛집"),
-                        jsonPath("$.places[0].category").value("식당")
+                        jsonPath("$.places[0].category").value("식당"),
+                        jsonPath("$.places[0].image_url").value("www.image.com")
                 );
     }
 
@@ -195,6 +219,7 @@ class CourseControllerTest {
                 .name("건대 풀코스")
                 .description("건대 핫플 요약 코스")
                 .score(5.0)
+                .imageUrl("www.image.com")
                 .build();
 
         GetCourseListResponse response = GetCourseListResponse.builder()
@@ -215,6 +240,7 @@ class CourseControllerTest {
                         jsonPath("$.courses[0].name").value("건대 풀코스"),
                         jsonPath("$.courses[0].description").value("건대 핫플 요약 코스"),
                         jsonPath("$.courses[0].score").value(5.0),
+                        jsonPath("$.courses[0].image_url").value("www.image.com"),
                         jsonPath("$.has_next").value(false)
                 );
     }
@@ -229,6 +255,7 @@ class CourseControllerTest {
                 .name("건대 풀코스")
                 .description("건대 핫플 요약 코스")
                 .score(5.0)
+                .imageUrl("www.image.com")
                 .build();
 
         GetCourseListResponse response = GetCourseListResponse.builder()
@@ -249,6 +276,7 @@ class CourseControllerTest {
                         jsonPath("$.courses[0].name").value("건대 풀코스"),
                         jsonPath("$.courses[0].description").value("건대 핫플 요약 코스"),
                         jsonPath("$.courses[0].score").value(5.0),
+                        jsonPath("$.courses[0].image_url").value("www.image.com"),
                         jsonPath("$.has_next").value(false)
                 );
     }

--- a/src/test/java/com/ku/covigator/domain/CoursePlaceTest.java
+++ b/src/test/java/com/ku/covigator/domain/CoursePlaceTest.java
@@ -1,0 +1,22 @@
+package com.ku.covigator.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoursePlaceTest {
+
+    @DisplayName("장소 이미지를 추가한다.")
+    @Test
+    void addImageUrl() {
+        //given
+        CoursePlace place = CoursePlace.builder().build();
+
+        //when
+        place.addImageUrl("www.covi.com");
+
+        //then
+        assertThat(place.getImageUrl()).isEqualTo("www.covi.com");
+    }
+}

--- a/src/test/java/com/ku/covigator/domain/CourseTest.java
+++ b/src/test/java/com/ku/covigator/domain/CourseTest.java
@@ -53,4 +53,5 @@ class CourseTest {
         //then
         assertEquals(0L, course.getDibsCnt());
     }
+
 }

--- a/src/test/java/com/ku/covigator/domain/CourseTest.java
+++ b/src/test/java/com/ku/covigator/domain/CourseTest.java
@@ -3,6 +3,7 @@ package com.ku.covigator.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CourseTest {
@@ -52,6 +53,41 @@ class CourseTest {
 
         //then
         assertEquals(0L, course.getDibsCnt());
+    }
+
+    @DisplayName("썸네일 이미지가 존재하지 않는 경우 null을 반환한다.")
+    @Test
+    void getNullThumbnailImage() {
+        //given
+        Course course = Course.builder().build();
+
+        //when
+        String thumbnailImage = course.getThumbnailImage();
+
+        //then
+        assertNull(thumbnailImage);
+    }
+
+    @DisplayName("썸네일 이미지가 존재하면 url을 반환한다.")
+    @Test
+    void getThumbnailImage() {
+        //given
+        Course course = Course.builder().build();
+        CoursePlace place = CoursePlace.builder()
+                .course(course)
+                .address("광진구")
+                .name("가츠시")
+                .description("공대생 추천 맛집")
+                .category("식당")
+                .imageUrl("www.image.com")
+                .build();
+        course.addPlace(place);
+
+        //when //then
+        String thumbnailImage = course.getThumbnailImage();
+
+        //then
+        assertThat(thumbnailImage).isEqualTo("www.image.com");
     }
 
 }

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -129,7 +129,7 @@ class AuthServiceTest {
         MockMultipartFile imageFile = new MockMultipartFile(
                 "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
         );
-        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class), any()))
                 .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
 
         //when
@@ -165,7 +165,7 @@ class AuthServiceTest {
         MockMultipartFile imageFile = new MockMultipartFile(
                 "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
         );
-        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class), any()))
                 .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
 
         //when //then
@@ -199,7 +199,7 @@ class AuthServiceTest {
         MockMultipartFile imageFile = new MockMultipartFile(
                 "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
         );
-        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class), any()))
                 .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
 
         //when // then
@@ -222,7 +222,7 @@ class AuthServiceTest {
         MockMultipartFile imageFile = new MockMultipartFile(
                 "image", "test-image.jpg", "image/jpeg", "dummy-image-content".getBytes()
         );
-        Mockito.when(s3Service.uploadImage(any(MultipartFile.class)))
+        Mockito.when(s3Service.uploadImage(any(MultipartFile.class), any()))
                 .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
 
         //when

--- a/src/test/java/com/ku/covigator/service/S3ServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/S3ServiceTest.java
@@ -35,7 +35,7 @@ class S3ServiceTest {
         );
 
         //when
-        String uploadedImageUrl = s3Service.uploadImage(imageFile);
+        String uploadedImageUrl = s3Service.uploadImage(imageFile, "profile");
 
         //then
         assertThat(uploadedImageUrl).contains("test-image.jpg");

--- a/src/test/java/com/ku/covigator/service/S3ServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/S3ServiceTest.java
@@ -35,10 +35,12 @@ class S3ServiceTest {
         );
 
         //when
-        String uploadedImageUrl = s3Service.uploadImage(imageFile, "profile");
+        String uploadedProfileImageUrl = s3Service.uploadImage(imageFile, "profile");
+        String uploadedPlaceImageUrl = s3Service.uploadImage(imageFile, "place");
 
         //then
-        assertThat(uploadedImageUrl).contains("test-image.jpg");
+        assertThat(uploadedProfileImageUrl).contains("test-image.jpg");
+        assertThat(uploadedPlaceImageUrl).contains("test-image.jpg");
     }
 
 }


### PR DESCRIPTION
## 📝 작업사항

- [x] 커뮤니티 코스 등록 API에서 이미지를 받도록 수정 (`@RequestPart List<MultiPartFile>`: 여러개의 이미지를 받을 수 있도록)
- [x] 커뮤니티 코스 등록 시 장소 이미지 url을 s3에 업로드 하는 로직 추가
- [x] 코스 관련 DTO에 장소 이미지 url 추가
- [x] 코스 썸네일 이미지를 가져오면서 발생하는 n+1 쿼리 문제 해결
- [x] 위의 변경 사항으로 인한 테스트 코드 수정 

## 참고사항
<img width="793" alt="스크린샷 2024-09-23 오전 1 46 24" src="https://github.com/user-attachments/assets/338a0711-0192-4ed9-8a40-81b9a9f95219">


- FE에서 이미지를 여러개 전송할 때, `postCourseRequest`안의 `places` 순서와 해당하는 이미지 순서가 일치하는지 반드시 확인해야 함