### PR TITLE
[Style] DTO 클래스 이름 수정

### DIFF
--- a/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseInfoResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseInfoResponse.java
@@ -10,16 +10,16 @@ import java.util.List;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GetCommunityCourseInfoResponse(Long courseId, String courseName, String courseDescription, Long dibsCnt,
-                                             Boolean dibs, List<PlaceDto> places) {
+                                             Boolean dibs, List<PlaceList> places) {
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record PlaceDto(Long placeId, String placeName, String placeDescription, String category, String imageUrl) {
+    public record PlaceList(Long placeId, String placeName, String placeDescription, String category, String imageUrl) {
     }
 
     public static GetCommunityCourseInfoResponse from(Course course, boolean dibs) {
-        List<PlaceDto> places = course.getPlaces().stream()
-                .map(place -> PlaceDto.builder()
+        List<PlaceList> places = course.getPlaces().stream()
+                .map(place -> PlaceList.builder()
                         .placeId(place.getId())
                         .placeDescription(place.getDescription())
                         .placeName(place.getName())

--- a/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetCommunityCourseListResponse.java
@@ -12,16 +12,16 @@ import java.util.stream.Collectors;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record GetCommunityCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
+public record GetCommunityCourseListResponse(List<CourseList> courses, Boolean hasNext) {
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record CourseDto(Long courseId, String name, String description, Double score, Boolean dibs, String imageUrl) {
+    public record CourseList(Long courseId, String name, String description, Double score, Boolean dibs, String imageUrl) {
     }
 
     public static GetCommunityCourseListResponse from(Slice<Course> courseSlice, Set<Long> dibsCourseId) {
-        List<CourseDto> courseDtos = courseSlice.getContent().stream()
-                .map(course -> CourseDto.builder()
+        List<CourseList> courseDtos = courseSlice.getContent().stream()
+                .map(course -> CourseList.builder()
                         .courseId(course.getId())
                         .name(course.getName())
                         .description(course.getDescription())

--- a/src/main/java/com/ku/covigator/dto/response/GetDibsCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetDibsCourseListResponse.java
@@ -10,16 +10,16 @@ import java.util.List;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record GetDibsCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
+public record GetDibsCourseListResponse(List<DibsCourseList> courses, Boolean hasNext) {
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record CourseDto(Long courseId, String name, String description, Double score, String imageUrl) {
+    public record DibsCourseList(Long courseId, String name, String description, Double score, String imageUrl) {
     }
 
     public static GetDibsCourseListResponse from(Slice<Course> courseSlice) {
-        List<CourseDto> courseDtos = courseSlice.getContent().stream()
-                .map(course -> CourseDto.builder()
+        List<DibsCourseList> courseDtos = courseSlice.getContent().stream()
+                .map(course -> DibsCourseList.builder()
                         .name(course.getName())
                         .description(course.getDescription())
                         .score(course.getAvgScore())

--- a/src/main/java/com/ku/covigator/dto/response/GetMyCourseListResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetMyCourseListResponse.java
@@ -7,20 +7,19 @@ import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
-import java.util.Set;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record GetMyCourseListResponse(List<CourseDto> courses, Boolean hasNext) {
+public record GetMyCourseListResponse(List<MyCourseList> courses, Boolean hasNext) {
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record CourseDto(Long courseId, String name, String description, Double score, String imageUrl, Character isPublic) {
+    public record MyCourseList(Long courseId, String name, String description, Double score, String imageUrl, Character isPublic) {
     }
 
     public static GetMyCourseListResponse from(Slice<Course> courseSlice) {
-        List<CourseDto> courseDtos = courseSlice.getContent().stream()
-                .map(course -> CourseDto.builder()
+        List<MyCourseList> courseDtos = courseSlice.getContent().stream()
+                .map(course -> MyCourseList.builder()
                         .name(course.getName())
                         .description(course.getDescription())
                         .score(course.getAvgScore())

--- a/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/CourseControllerTest.java
@@ -100,7 +100,7 @@ class CourseControllerTest {
         //given
         Long memberId = 1L;
 
-        GetCommunityCourseListResponse.CourseDto courseDto = GetCommunityCourseListResponse.CourseDto.builder()
+        GetCommunityCourseListResponse.CourseList courseDto = GetCommunityCourseListResponse.CourseList.builder()
                 .courseId(1L)
                 .name("건대 풀코스")
                 .description("건대 핫플 요약 코스")
@@ -109,7 +109,7 @@ class CourseControllerTest {
                 .imageUrl("www.imageUrl.com")
                 .build();
 
-        GetCommunityCourseListResponse.CourseDto courseDto2 = GetCommunityCourseListResponse.CourseDto.builder()
+        GetCommunityCourseListResponse.CourseList courseDto2 = GetCommunityCourseListResponse.CourseList.builder()
                 .courseId(2L)
                 .name("건대 풀코스2")
                 .description("건대 핫플 요약 코스2")
@@ -162,7 +162,7 @@ class CourseControllerTest {
         Long memberId = 1L;
         Long courseId = 1L;
 
-        GetCommunityCourseInfoResponse.PlaceDto placeDto = GetCommunityCourseInfoResponse.PlaceDto.builder()
+        GetCommunityCourseInfoResponse.PlaceList placeDto = GetCommunityCourseInfoResponse.PlaceList.builder()
                 .placeName("가츠시")
                 .placeDescription("공대생 추천 맛집")
                 .imageUrl("www.image.com")
@@ -216,7 +216,7 @@ class CourseControllerTest {
         //given
         Long memberId = 1L;
 
-        GetDibsCourseListResponse.CourseDto courseDto = GetDibsCourseListResponse.CourseDto.builder()
+        GetDibsCourseListResponse.DibsCourseList courseDto = GetDibsCourseListResponse.DibsCourseList.builder()
                 .name("건대 풀코스")
                 .description("건대 핫플 요약 코스")
                 .score(5.0)
@@ -252,7 +252,7 @@ class CourseControllerTest {
         //given
         Long memberId = 1L;
 
-        GetMyCourseListResponse.CourseDto courseDto = GetMyCourseListResponse.CourseDto.builder()
+        GetMyCourseListResponse.MyCourseList courseDto = GetMyCourseListResponse.MyCourseList.builder()
                 .name("건대 풀코스")
                 .description("건대 핫플 요약 코스")
                 .score(5.0)


### PR DESCRIPTION
## 📌  요약

- 기존에 중첩 클래스로 사용되던 DTO 클래스들의 이름이 동일하여 스웨거에서 제대로 인식하지 못하는 문제가 발생.
- 내부 클래스들의 이름 변경