### PR TITLE
[Feat] 예외 처리 로직 구현

### DIFF
--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +23,14 @@ public class AuthController {
 
     @Operation(summary = "로컬 로그인")
     @PostMapping("/sign-in")
-    public ResponseEntity<AccessTokenResponse> signIn(@RequestBody PostSignInRequest request) {
+    public ResponseEntity<AccessTokenResponse> signIn(@RequestBody @Valid PostSignInRequest request) {
         String accessToken = authService.signIn(request.email(), request.password());
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
     }
 
     @Operation(summary = "회원가입")
     @PostMapping("/sign-up")
-    public ResponseEntity<AccessTokenResponse> signUp(@RequestPart(value = "postSignUpRequest") PostSignUpRequest request,
+    public ResponseEntity<AccessTokenResponse> signUp(@RequestPart(value = "postSignUpRequest") @Valid PostSignUpRequest request,
                                                       @RequestPart(value = "image", required = false) MultipartFile image) {
         String accessToken = authService.signUp(request.toEntity(), image);
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));

--- a/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
+++ b/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
@@ -5,15 +5,73 @@ import com.ku.covigator.exception.CovigatorException;
 import com.ku.covigator.support.slack.SlackAlarmGenerator;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+import java.util.Objects;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ControllerAdvice {
 
     private final SlackAlarmGenerator slackAlarmGenerator;
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleInputFieldException(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9000, Objects.requireNonNull(e.getFieldError()).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleJsonException() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9001, "Json 형식이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(HttpMediaTypeException.class)
+    public ResponseEntity<ErrorResponse> handleContentTypeException() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9002, "ContentType 값이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleRequestMethodException() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9003, "해당 Http Method에 맞는 API가 존재하지 않습니다."));
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9004, "이미지 용량이 너무 큽니다."));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestParamException() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9005, "요청 파라미터 이름이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingMultiPartParamException( ) {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9006, "요청 MultipartFile 파라미터 이름이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(FileUploadException.class)
+    public ResponseEntity<ErrorResponse> handleFileUploadException() {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9007, "요청 파일이 올바르지 않습니다. 파일 손상 여부나 요청 형식을 확인해주세요."));
+    }
 
     @ExceptionHandler(CovigatorException.class)
     public ResponseEntity<ErrorResponse> handleCovigatorException(CovigatorException e) {

--- a/src/main/java/com/ku/covigator/controller/CourseController.java
+++ b/src/main/java/com/ku/covigator/controller/CourseController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,7 @@ public class CourseController {
     @Operation(summary = "코스 등록")
     @PostMapping("/community/courses")
     public ResponseEntity<Void> addCommunityCourse(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
-                                                   @RequestPart(value = "postCourseRequest") PostCourseRequest request,
+                                                   @RequestPart(value = "postCourseRequest") @Valid PostCourseRequest request,
                                                    @RequestPart(value = "image", required = false) List<MultipartFile> images) {
         courseService.addCommunityCourse(memberId, request, images);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/ku/covigator/controller/ReviewController.java
+++ b/src/main/java/com/ku/covigator/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.ku.covigator.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -27,7 +28,7 @@ public class ReviewController {
     public ResponseEntity<Void> addReview(
             @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @PathVariable(name = "course_id") Long courseId,
-            @RequestBody PostReviewRequest request) {
+            @RequestBody @Valid PostReviewRequest request) {
         reviewService.addReview(memberId, courseId, request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/ku/covigator/controller/WebSocketController.java
+++ b/src/main/java/com/ku/covigator/controller/WebSocketController.java
@@ -3,6 +3,7 @@ package com.ku.covigator.controller;
 import com.ku.covigator.dto.request.ChatMessageRequest;
 import com.ku.covigator.dto.response.SaveMessageResponse;
 import com.ku.covigator.service.ChatService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.*;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -22,7 +23,7 @@ public class WebSocketController {
     @SendTo("/topic/chat/{course_id}")
     public void sendMessage(@DestinationVariable(value = "course_id") Long courseId,
                             SimpMessageHeaderAccessor accessor,
-                            @Payload ChatMessageRequest request) {
+                            @Payload @Valid ChatMessageRequest request) {
         Long memberId = Long.parseLong(Objects.requireNonNull(accessor.getSessionAttributes()).get("memberId").toString());
         SaveMessageResponse saveMessageResponse = chatService.saveMessage(memberId, courseId, request.message());
         simpleMessageSendingOperations.convertAndSend("/topic/chat/" + courseId, saveMessageResponse);

--- a/src/main/java/com/ku/covigator/domain/travelstyle/ActivityType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/ActivityType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum ActivityType {
 
-    REST, ACTIVITY
+    REST, ACTIVITY, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/AreaType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/AreaType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum AreaType {
 
-    NATURE, CITY
+    NATURE, CITY, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/Familiarity.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/Familiarity.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum Familiarity {
 
-    NEW, FAMILIAR
+    NEW, FAMILIAR, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/PhotoPriority.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/PhotoPriority.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum PhotoPriority {
 
-    IMPORTANT, NOT_IMPORTANT
+    IMPORTANT, NOT_IMPORTANT, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/PlanningType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/PlanningType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum PlanningType {
 
-    PLANNED, SITUATIONAL
+    PLANNED, SITUATIONAL, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/Popularity.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/Popularity.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum Popularity {
 
-    WELL_KNOWN, NOT_WIDELY_KNOWN
+    WELL_KNOWN, NOT_WIDELY_KNOWN, NEUTRALITY
 
 }

--- a/src/main/java/com/ku/covigator/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/ChatMessageRequest.java
@@ -1,5 +1,10 @@
 package com.ku.covigator.dto.request;
 
-public record ChatMessageRequest(String message) {
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ChatMessageRequest(
+        @NotNull(message = "NULL일 수 없습니다.")
+        @Size(min = 1, max = 300, message = "글자 길이는 1~300자여야 합니다.") String message) {
 
 }

--- a/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
@@ -8,6 +8,7 @@ import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.support.GeometryUtils;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 import java.util.List;
@@ -16,8 +17,12 @@ import java.util.stream.Collectors;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PostCourseRequest(
-        @NotBlank(message = "공백일 수 없습니다.") String courseName,
-        String courseDescription,
+
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 10, message = "글자 길이는 1~10자여야 합니다.") String courseName,
+
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 20, message = "글자 길이는 1~20자여야 합니다.") String courseDescription,
         List<PlaceDto> places,
         @NotNull(message = "NULL일 수 없습니다.") Character isPublic
 ) {
@@ -25,10 +30,12 @@ public record PostCourseRequest(
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record PlaceDto(
-            @NotBlank(message = "공백일 수 없습니다.") String placeName,
+            @NotBlank(message = "공백일 수 없습니다.")
+            @Size(min = 1, max = 15, message = "글자 길이는 1~15자여야 합니다.")String placeName,
             String address,
-            @NotBlank(message = "공백일 수 없습니다.") String category,
-            String description,
+            @NotNull(message = "NULL일 수 없습니다.") String category,
+            @NotBlank(message = "공백일 수 없습니다.")
+            @Size(min = 1, max = 50, message = "글자 길이는 1~50자여야 합니다.") String description,
             @NotNull(message = "NULL일 수 없습니다.") Double latitude,
             @NotNull(message = "NULL일 수 없습니다.") Double longitude) {
     }

--- a/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
@@ -6,6 +6,8 @@ import com.ku.covigator.domain.Course;
 import com.ku.covigator.domain.CoursePlace;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.support.GeometryUtils;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.List;
@@ -13,11 +15,22 @@ import java.util.stream.Collectors;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record PostCourseRequest(String courseName, String courseDescription, List<PlaceDto> places, Character isPublic) {
+public record PostCourseRequest(
+        @NotBlank(message = "공백일 수 없습니다.") String courseName,
+        String courseDescription,
+        List<PlaceDto> places,
+        @NotNull(message = "NULL일 수 없습니다.") Character isPublic
+) {
 
     @Builder
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record PlaceDto(String placeName, String address, String category, String description, Double latitude, Double longitude) {
+    public record PlaceDto(
+            @NotBlank(message = "공백일 수 없습니다.") String placeName,
+            String address,
+            @NotBlank(message = "공백일 수 없습니다.") String category,
+            String description,
+            @NotNull(message = "NULL일 수 없습니다.") Double latitude,
+            @NotNull(message = "NULL일 수 없습니다.") Double longitude) {
     }
 
     public Course toCourseEntity(Member member) {

--- a/src/main/java/com/ku/covigator/dto/request/PostReviewRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostReviewRequest.java
@@ -3,10 +3,17 @@ package com.ku.covigator.dto.request;
 import com.ku.covigator.domain.Course;
 import com.ku.covigator.domain.Review;
 import com.ku.covigator.domain.member.Member;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 
 @Builder
-public record PostReviewRequest(Integer score, String comment) {
+public record PostReviewRequest(
+        @NotNull(message = "NULL일 수 없습니다.")
+        @Min(value = 1, message = "값이 1보다 작을 수 없습니다.")
+        @Max(value = 5, message = "값이 5보다 클 수 없습니다.") Integer score,
+
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 150, message = "글자 길이는 1~150자여야 합니다.") String comment) {
 
     public Review toEntity(Member member, Course course) {
         return Review.builder()

--- a/src/main/java/com/ku/covigator/dto/request/PostSignInRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostSignInRequest.java
@@ -1,5 +1,10 @@
 package com.ku.covigator.dto.request;
 
-public record PostSignInRequest(String email, String password) {
+import jakarta.validation.constraints.NotBlank;
+
+public record PostSignInRequest(
+        @NotBlank(message = "공백일 수 없습니다.") String email,
+        @NotBlank(message = "공백일 수 없습니다.") String password
+) {
 
 }

--- a/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
@@ -4,17 +4,17 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.member.Platform;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PostSignUpRequest(
-        @NotBlank(message = "공백일 수 없습니다.") String nickname,
-        @Email String email,
-        @NotBlank(message = "공백일 수 없습니다.") String password) {
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 10, message = "글자 길이는 1~10자여야 합니다.") String nickname,
+        @Email(message = "올바른 이메일 형식이 아닙니다.") String email,
+        @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
+                message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String password) {
     public Member toEntity() {
         return Member.builder()
                 .email(email)

--- a/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
@@ -4,17 +4,22 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.member.Platform;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record PostSignUpRequest(String imageUrl, String nickname, String email, String password) {
+public record PostSignUpRequest(
+        @NotBlank(message = "공백일 수 없습니다.") String nickname,
+        @Email String email,
+        @NotBlank(message = "공백일 수 없습니다.") String password) {
     public Member toEntity() {
         return Member.builder()
                 .email(email)
                 .nickname(nickname)
                 .password(password)
-                .imageUrl(imageUrl)
                 .platform(Platform.LOCAL)
                 .build();
     }

--- a/src/main/java/com/ku/covigator/exception/badrequest/DuplicateMemberException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/DuplicateMemberException.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 public class DuplicateMemberException extends BadRequestException{
 
     public DuplicateMemberException() {
-        super(1002, "이미 가입된 사용자입니다.");
+        super(3002, "이미 가입된 사용자입니다.");
     }
 }

--- a/src/main/java/com/ku/covigator/exception/badrequest/PasswordMismatchException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/PasswordMismatchException.java
@@ -2,7 +2,7 @@ package com.ku.covigator.exception.badrequest;
 
 public class PasswordMismatchException extends BadRequestException{
     public PasswordMismatchException() {
-        super(1001, "비밀번호가 일치하지 않습니다.");
+        super(3001, "비밀번호가 일치하지 않습니다.");
     }
 
 }

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -63,10 +63,9 @@ class AuthControllerTest {
     void signUp() throws Exception {
         //given
         PostSignUpRequest request = PostSignUpRequest.builder()
-                .email("www.covi.com")
+                .email("covi123@naver.com")
                 .nickname("covi")
-                .imageUrl("covi@naver.com")
-                .imageUrl("covigator123")
+                .password("covi123!@#")
                 .build();
 
         MockMultipartFile imageFile = new MockMultipartFile(


### PR DESCRIPTION
## 📌 요약

- 사용자의 잘못된 요청에 대한 검증 로직을 `ControllerAdvice`에 추가한다.

## 📝 작업사항

- [x] 사용자 입력 요청에 대한 필드 에러를 검증
- [x] JSON 형식을 검증
- [x] Content-Type을 검증
- [x] API 검증
- [x] Multipart 요청 검증
- [x] 요청 파라미터 이름 검증
- [x] 요청 multipartfile 이름 검증
- [x] 파일 업로드 검증