### PR TITLE
[Fix] Slack 알림 전송 비동기 처리 시 HttpServletRequest의 생명주기가 먼저 종료되어 발생하던 에러 해결

### DIFF
--- a/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
+++ b/src/main/java/com/ku/covigator/controller/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.response.ErrorResponse;
 import com.ku.covigator.exception.CovigatorException;
+import com.ku.covigator.support.slack.RequestInfo;
 import com.ku.covigator.support.slack.SlackAlarmGenerator;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -80,7 +81,8 @@ public class ControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleInternalException(Exception e, HttpServletRequest request) {
-        slackAlarmGenerator.sendSlackAlertErrorLog(e, request);
+        RequestInfo requestInfo = RequestInfo.from(request);
+        slackAlarmGenerator.sendSlackAlertErrorLog(e, requestInfo);
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(9999, "서버 복구중입니다. 잠시만 기다려주세요."));
     }

--- a/src/main/java/com/ku/covigator/support/slack/SlackAlarmGenerator.java
+++ b/src/main/java/com/ku/covigator/support/slack/SlackAlarmGenerator.java
@@ -28,9 +28,7 @@ public class SlackAlarmGenerator {
     private final Slack slack = Slack.getInstance();
 
     @Async
-    public void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
-
-        RequestInfo requestInfo = RequestInfo.from(request);
+    public void sendSlackAlertErrorLog(Exception e, RequestInfo requestInfo) {
 
         try {
             slack.send(slackProperties.getUrl(), payload(p -> p


### PR DESCRIPTION
## 📌  요약

-  Slack 알림 전송 비동기 처리 시 HttpServletRequest의 생명주기가 먼저 종료되어 에러가 발생함

## 🐛 버그

- `java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade`

## 📍 원인

<img width="771" alt="스크린샷 2024-09-29 오후 2 55 05" src="https://github.com/user-attachments/assets/d72fadad-5284-4aca-b36a-933c37754ae6">

- 에러 로그를 작성하여 Slack 알림으로 전송하기 위해 `HttpServletRequest` 객체를 파라미터로 전달하였다. 

<img width="600" alt="스크린샷 2024-09-29 오후 2 56 47" src="https://github.com/user-attachments/assets/fa29e156-801a-4df3-9e67-b6eef5e2ff6a">

- 하지만 `sendSlackAlertErrorLog` 함수는 `@Async`에 의해 비동기적으로 처리되고 있기 때문에 `HttpServletRequest`의 생명주기가 먼저 종료되는 경우 더 이상 객체에 접근할 수 없게 되는 문제가 발생하여 Slack 알림을 정상적으로 전송하지 못하는 문제가 발생하였다.

## 🖊️ 해결방법

- `sendSlackAlertErrorLog` 함수를 비동기로 호출하기 이전에 먼저 `HttpServletRequest`에서 사용할 정보들을 미리 `RequestInfo` 객체에 담아 `RequestInfo` 객체를 파라미터로 전달한다.