### PR TITLE
[Fix] 컬렉션 데이터를 메모리 상에서 페이징으로 가져오는 문제 해결

### DIFF
--- a/src/main/java/com/ku/covigator/repository/CourseRepository.java
+++ b/src/main/java/com/ku/covigator/repository/CourseRepository.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
-    @EntityGraph(attributePaths = "places")
     Slice<Course> findAllCoursesByIsPublic(Pageable pageable, Character isPublic);
 
     @EntityGraph(attributePaths = "places")
@@ -20,12 +19,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("""
     SELECT c
     FROM Course c, Dibs d
-    LEFT JOIN FETCH c.places p
     WHERE d.member.id = :memberId AND d.course.id = c.id AND c.isPublic = "Y"
     ORDER BY d.createdAt DESC
     """)
     Slice<Course> findLikedCoursesByMemberId(Long memberId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "places"})
+    @EntityGraph(attributePaths = "member")
     Slice<Course> findMyCoursesByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/ku/covigator/service/CourseService.java
+++ b/src/main/java/com/ku/covigator/service/CourseService.java
@@ -47,8 +47,8 @@ public class CourseService {
         //코스_장소 등록
         List<CoursePlace> coursePlaces = request.toCoursePlaceEntity(course);
 
-        // S3에 프로필 이미지 업로드
-        if (!images.isEmpty()) {
+        // S3에 장소 이미지 업로드
+        if (images != null && !images.isEmpty()) {
             for (int iter = 0; iter < images.size(); iter++) {
                 String uploadedImageUrl = s3Service.uploadImage(images.get(iter), "place");
                 coursePlaces.get(iter).addImageUrl(uploadedImageUrl);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        query:
+          fail_on_pagination_over_collection_fetch: true
+        default_batch_fetch_size: 10
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 📌  요약

-  전체 커뮤니티 코스 조회, 마이 코스 조회, 찜 코스 조회 시 컬렉션 데이터를 메모리 상에서 페이징으로 가져오는 문제 발생

## 🐛 버그

- `hhh90003004: firstresult/maxresults specified with collection fetch; applying in memory`

## 📍 원인

- 1:N 관계의 Entity 객체들을 조회할 때, `Fetch Join`과 `Pagination`을 같이 사용하는 경우 발생하는 쿼리에 `Limit`, `Offset` 절이 날아가지 않는다. 대신 페이징을 처리하기 위해 조건에 해당하는 모든 데이터를 조회하여 메모리에 올려둔 다음에 처리한다. 모든 데이터를 조회하기 때문에 쿼리  속도가 느릴 수 있을 뿐만 아니라, 조회한 모든 데이터를 메모리에 올려두기 때문에 메모리 성능 측면에서도 매우 좋지 않다.

## 🖊️ 해결방법

- `fail_on_pagination_over_collection_fetch`을 `true`로 설정하여 페이징을 애플리케이션 레벨에서 처리하는 경우 예외를 발생시켜 사전에 방지할 수 있도록 한다.
- 기존에 1:N 관계의 Entity 객체 조회 시 Fetch Join을 사용하던 것들을 모두 삭제한다. 대신 `default_batch_fetch_size`를 10으로 설정하여 지연로딩으로 발생해야 하는 쿼리를 IN절로 한번에 최대 10개씩 모아보낼 수 있도록 한다. (해당 서비스는 페이징을 기본적으로 10개씩 처리하기 때문에 `default_batch_fetch_size` 값을 10으로 설정한다.)