### PR TITLE
[Feat] Chat 엔티티에 유저 프로필 이미지, 유저 ID 추가 및 관련 DTO에서 해당 필드를 반환하도록 구현

### DIFF
--- a/src/main/java/com/ku/covigator/controller/ChatController.java
+++ b/src/main/java/com/ku/covigator/controller/ChatController.java
@@ -2,8 +2,10 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.domain.Chat;
 import com.ku.covigator.dto.response.GetChatHistoryResponse;
+import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +24,11 @@ public class ChatController {
 
     @Operation(summary = "채팅 기록 조회")
     @GetMapping("/chat/{course_id}")
-    public ResponseEntity<GetChatHistoryResponse> getChatHistory(@PathVariable(value = "course_id") Long courseId) {
+    public ResponseEntity<GetChatHistoryResponse> getChatHistory(
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
+            @PathVariable(value = "course_id") Long courseId) {
         List<Chat> chatList = chatService.getChatHistory(courseId);
-        return ResponseEntity.ok(GetChatHistoryResponse.from(chatList));
+        return ResponseEntity.ok(GetChatHistoryResponse.from(memberId, chatList));
     }
 
 }

--- a/src/main/java/com/ku/covigator/domain/Chat.java
+++ b/src/main/java/com/ku/covigator/domain/Chat.java
@@ -17,13 +17,17 @@ public class Chat {
     private Long courseId;
     private String timestamp;
     private String nickname;
+    private String profileImageUrl;
+    private Long memberId;
     private String message;
 
     @Builder
-    public Chat(Long courseId, String timestamp, String nickname, String message) {
+    public Chat(Long courseId, String timestamp, String nickname, String message, String profileImageUrl, Long memberId) {
         this.courseId = courseId;
         this.timestamp = timestamp;
         this.nickname = nickname;
         this.message = message;
+        this.profileImageUrl = profileImageUrl;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
@@ -5,22 +5,24 @@ import lombok.Builder;
 
 import java.util.List;
 
-public record GetChatHistoryResponse(List<ChatDto> chat) {
+public record GetChatHistoryResponse(Long myId, List<ChatDto> chat) {
 
     @Builder
-    public record ChatDto(String nickname, String timestamp, String message) {
+    public record ChatDto(String nickname, String timestamp, String message, String profileImageUrl, Long memberId) {
     }
 
-    public static GetChatHistoryResponse from(List<Chat> chatList) {
+    public static GetChatHistoryResponse from(Long myId, List<Chat> chatList) {
 
         List<ChatDto> chatDtos = chatList.stream()
                 .map(chat -> ChatDto.builder()
                         .nickname(chat.getNickname())
                         .message(chat.getMessage())
                         .timestamp(chat.getTimestamp())
+                        .profileImageUrl(chat.getProfileImageUrl())
+                        .memberId(chat.getMemberId())
                         .build()
                 ).toList();
 
-        return new GetChatHistoryResponse(chatDtos);
+        return new GetChatHistoryResponse(myId, chatDtos);
     }
 }

--- a/src/main/java/com/ku/covigator/dto/response/SaveMessageResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/SaveMessageResponse.java
@@ -1,17 +1,20 @@
 package com.ku.covigator.dto.response;
 
+import com.ku.covigator.domain.member.Member;
 import lombok.Builder;
 
 import java.sql.Timestamp;
 
 @Builder
-public record SaveMessageResponse(String sender, String message, String timestamp) {
+public record SaveMessageResponse(String nickname, String message, String timestamp, Long memberId, String profileImageUrl) {
 
-    public static SaveMessageResponse of(String sender, String message) {
+    public static SaveMessageResponse from(Member member, String message) {
         return SaveMessageResponse.builder()
-                .sender(sender)
+                .nickname(member.getNickname())
                 .message(message)
                 .timestamp(String.valueOf(new Timestamp(System.currentTimeMillis())))
+                .memberId(member.getId())
+                .profileImageUrl(member.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -50,6 +50,8 @@ public class ChatService {
                 .nickname(member.getNickname())
                 .timestamp(String.valueOf(new Timestamp(System.currentTimeMillis())))
                 .courseId(courseId)
+                .memberId(member.getId())
+                .profileImageUrl(member.getImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -41,7 +41,7 @@ public class ChatService {
 
         chatRepository.save(chat);
 
-        return SaveMessageResponse.of(member.getNickname(), message);
+        return SaveMessageResponse.from(member, message);
     }
 
     private Chat buildChat(Long courseId, String message, Member member) {

--- a/src/test/java/com/ku/covigator/service/ChatServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/ChatServiceTest.java
@@ -119,7 +119,9 @@ class ChatServiceTest {
         //then
         Assertions.assertAll(
                 () -> assertThat(response.message()).isEqualTo("여기 좋아요"),
-                () -> assertThat(response.sender()).isEqualTo("김코비")
+                () -> assertThat(response.nickname()).isEqualTo("김코비"),
+                () -> assertThat(response.memberId()).isEqualTo(savedMember.getId()),
+                () -> assertThat(response.profileImageUrl()).isEqualTo(savedMember.getImageUrl())
         );
     }
 


### PR DESCRIPTION
## 📌 요약

- `Chat` 엔티티에 유저 프로필 이미지, 유저 ID 추가 및 관련 DTO에서 해당 필드를 반환하도록 구현

## 📝 작업사항

- [x] Chat 엔티티에 `memberId`, `profileImageUrl` 추가
- [x] `GetChatHistoryResponse` DTO에 `내 id`, `memberId`, `profileImageUrl` 추가
- [x] `SaveMessageResponse` DTO에 `memberId`, `profileImageUrl`