### PR TITLE
[Feat] 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/ku/covigator/controller/ChatController.java
+++ b/src/main/java/com/ku/covigator/controller/ChatController.java
@@ -2,8 +2,10 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.domain.Chat;
 import com.ku.covigator.dto.response.GetChatHistoryResponse;
+import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +24,11 @@ public class ChatController {
 
     @Operation(summary = "채팅 기록 조회")
     @GetMapping("/chat/{course_id}")
-    public ResponseEntity<GetChatHistoryResponse> getChatHistory(@PathVariable(value = "course_id") Long courseId) {
+    public ResponseEntity<GetChatHistoryResponse> getChatHistory(
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
+            @PathVariable(value = "course_id") Long courseId) {
         List<Chat> chatList = chatService.getChatHistory(courseId);
-        return ResponseEntity.ok(GetChatHistoryResponse.from(chatList));
+        return ResponseEntity.ok(GetChatHistoryResponse.from(memberId, chatList));
     }
 
 }

--- a/src/main/java/com/ku/covigator/controller/MemberController.java
+++ b/src/main/java/com/ku/covigator/controller/MemberController.java
@@ -1,0 +1,46 @@
+package com.ku.covigator.controller;
+
+import com.ku.covigator.dto.request.PatchMemberRequest;
+import com.ku.covigator.dto.request.PostVerifyNicknameRequest;
+import com.ku.covigator.exception.badrequest.PasswordVerificationException;
+import com.ku.covigator.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Member", description = "회원")
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "회원 정보 수정")
+    @PatchMapping("/{member_id}")
+    public ResponseEntity<Void> updateMember(
+            @PathVariable(value = "member_id") Long memberId,
+            @Valid @RequestBody PatchMemberRequest request
+            ) {
+
+        if (!request.password().equals(request.passwordVerification())) {
+            throw new PasswordVerificationException();
+        }
+
+        memberService.updateMember(memberId, request.nickname(), request.password());
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "닉네임 중복 확인")
+    @PostMapping("/nickname")
+    public ResponseEntity<Void> verifyNickname(
+            @Valid @RequestBody PostVerifyNicknameRequest request
+    ) {
+        memberService.verifyNicknameDuplication(request.nickname());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ku/covigator/domain/Chat.java
+++ b/src/main/java/com/ku/covigator/domain/Chat.java
@@ -17,13 +17,17 @@ public class Chat {
     private Long courseId;
     private String timestamp;
     private String nickname;
+    private String profileImageUrl;
+    private Long memberId;
     private String message;
 
     @Builder
-    public Chat(Long courseId, String timestamp, String nickname, String message) {
+    public Chat(Long courseId, String timestamp, String nickname, String message, String profileImageUrl, Long memberId) {
         this.courseId = courseId;
         this.timestamp = timestamp;
         this.nickname = nickname;
         this.message = message;
+        this.profileImageUrl = profileImageUrl;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/ku/covigator/domain/Course.java
+++ b/src/main/java/com/ku/covigator/domain/Course.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +48,7 @@ public class Course extends BaseTime {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "course")

--- a/src/main/java/com/ku/covigator/domain/Dibs.java
+++ b/src/main/java/com/ku/covigator/domain/Dibs.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -23,6 +25,7 @@ public class Dibs extends BaseTime{
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", referencedColumnName = "id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Course course;
 
     @Builder

--- a/src/main/java/com/ku/covigator/domain/Review.java
+++ b/src/main/java/com/ku/covigator/domain/Review.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,10 +27,12 @@ public class Review extends BaseTime{
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", referencedColumnName = "id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Course course;
 
     @Builder

--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -74,4 +74,9 @@ public class Member extends BaseTime {
     public void addImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void updateMemberInfo(String nickname, String password) {
+        this.nickname = nickname;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/ku/covigator/dto/request/PatchMemberRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PatchMemberRequest.java
@@ -1,0 +1,20 @@
+package com.ku.covigator.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record PatchMemberRequest(
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 10, message = "글자 길이는 1~10자여야 합니다.") String nickname,
+        @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
+                message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String password,
+        @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
+                message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String passwordVerification) {
+
+}

--- a/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
@@ -6,6 +6,7 @@ import com.ku.covigator.domain.Course;
 import com.ku.covigator.domain.CoursePlace;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.support.GeometryUtils;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -23,7 +24,7 @@ public record PostCourseRequest(
 
         @NotBlank(message = "공백일 수 없습니다.")
         @Size(min = 1, max = 20, message = "글자 길이는 1~20자여야 합니다.") String courseDescription,
-        List<PlaceDto> places,
+        @Valid List<PlaceDto> places,
         @NotNull(message = "NULL일 수 없습니다.") Character isPublic
 ) {
 

--- a/src/main/java/com/ku/covigator/dto/request/PostReviewRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostReviewRequest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 @Builder
 public record PostReviewRequest(
         @NotNull(message = "NULL일 수 없습니다.")
-        @Min(value = 1, message = "값이 1보다 작을 수 없습니다.")
+        @Min(value = 0, message = "값이 0보다 작을 수 없습니다.")
         @Max(value = 5, message = "값이 5보다 클 수 없습니다.") Integer score,
 
         @NotBlank(message = "공백일 수 없습니다.")

--- a/src/main/java/com/ku/covigator/dto/request/PostVerifyNicknameRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostVerifyNicknameRequest.java
@@ -1,0 +1,9 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PostVerifyNicknameRequest(
+        @NotBlank(message = "공백일 수 없습니다.")
+        @Size(min = 1, max = 10, message = "글자 길이는 1~10자여야 합니다.") String nickname) {
+}

--- a/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
@@ -5,22 +5,24 @@ import lombok.Builder;
 
 import java.util.List;
 
-public record GetChatHistoryResponse(List<ChatDto> chat) {
+public record GetChatHistoryResponse(Long myId, List<ChatDto> chat) {
 
     @Builder
-    public record ChatDto(String nickname, String timestamp, String message) {
+    public record ChatDto(String nickname, String timestamp, String message, String profileImageUrl, Long memberId) {
     }
 
-    public static GetChatHistoryResponse from(List<Chat> chatList) {
+    public static GetChatHistoryResponse from(Long myId, List<Chat> chatList) {
 
         List<ChatDto> chatDtos = chatList.stream()
                 .map(chat -> ChatDto.builder()
                         .nickname(chat.getNickname())
                         .message(chat.getMessage())
                         .timestamp(chat.getTimestamp())
+                        .profileImageUrl(chat.getProfileImageUrl())
+                        .memberId(chat.getMemberId())
                         .build()
                 ).toList();
 
-        return new GetChatHistoryResponse(chatDtos);
+        return new GetChatHistoryResponse(myId, chatDtos);
     }
 }

--- a/src/main/java/com/ku/covigator/dto/response/SaveMessageResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/SaveMessageResponse.java
@@ -1,17 +1,20 @@
 package com.ku.covigator.dto.response;
 
+import com.ku.covigator.domain.member.Member;
 import lombok.Builder;
 
 import java.sql.Timestamp;
 
 @Builder
-public record SaveMessageResponse(String sender, String message, String timestamp) {
+public record SaveMessageResponse(String nickname, String message, String timestamp, Long memberId, String profileImageUrl) {
 
-    public static SaveMessageResponse of(String sender, String message) {
+    public static SaveMessageResponse from(Member member, String message) {
         return SaveMessageResponse.builder()
-                .sender(sender)
+                .nickname(member.getNickname())
                 .message(message)
                 .timestamp(String.valueOf(new Timestamp(System.currentTimeMillis())))
+                .memberId(member.getId())
+                .profileImageUrl(member.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/ku/covigator/exception/badrequest/DuplicateMemberNicknameException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/DuplicateMemberNicknameException.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.exception.badrequest;
+
+public class DuplicateMemberNicknameException extends BadRequestException{
+
+    public DuplicateMemberNicknameException() {
+        super(3003, "이미 존재하는 닉네임입니다.");
+    }
+}

--- a/src/main/java/com/ku/covigator/exception/badrequest/PasswordVerificationException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/PasswordVerificationException.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.exception.badrequest;
+
+public class PasswordVerificationException extends BadRequestException {
+
+    public PasswordVerificationException() {
+        super(3004, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/ku/covigator/repository/MemberRepository.java
+++ b/src/main/java/com/ku/covigator/repository/MemberRepository.java
@@ -18,5 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     WHERE m.id=:memberId
     """)
     Optional<Member> findMemberWithDibsById(Long memberId);
+
+    Optional<Member> findByNickname(String nickname);
 }
 

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -50,6 +50,8 @@ public class ChatService {
                 .nickname(member.getNickname())
                 .timestamp(String.valueOf(new Timestamp(System.currentTimeMillis())))
                 .courseId(courseId)
+                .memberId(member.getId())
+                .profileImageUrl(member.getImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -41,7 +41,7 @@ public class ChatService {
 
         chatRepository.save(chat);
 
-        return SaveMessageResponse.of(member.getNickname(), message);
+        return SaveMessageResponse.from(member, message);
     }
 
     private Chat buildChat(Long courseId, String message, Member member) {

--- a/src/main/java/com/ku/covigator/service/MemberService.java
+++ b/src/main/java/com/ku/covigator/service/MemberService.java
@@ -1,0 +1,42 @@
+package com.ku.covigator.service;
+
+import com.ku.covigator.domain.member.Member;
+import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
+import com.ku.covigator.exception.notfound.NotFoundMemberException;
+import com.ku.covigator.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void updateMember(Long memberId, String nickname, String password) {
+
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        // 닉네임 중복 검증
+        verifyNicknameDuplication(nickname);
+
+        // 패스워드 인코딩
+        String encodedPassword = passwordEncoder.encode(password);
+        member.updateMemberInfo(nickname, encodedPassword);
+
+        // 회원 정보 수정
+        memberRepository.save(member);
+    }
+
+    public void verifyNicknameDuplication(String nickname) {
+        if(memberRepository.findByNickname(nickname).isPresent()) {
+            throw new DuplicateMemberNicknameException();
+        }
+    }
+}

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -2,8 +2,6 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.request.PostSignUpRequest;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
-import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
-import com.ku.covigator.security.jwt.JwtAuthInterceptor;
 import com.ku.covigator.dto.request.PostSignInRequest;
 import com.ku.covigator.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ComponentScan("com.ku.covigator.support")
+@ComponentScan({"com.ku.covigator.support", "com.ku.covigator.security.jwt"})
 @WebMvcTest(controllers = AuthController.class)
 class AuthControllerTest {
 
@@ -33,10 +31,6 @@ class AuthControllerTest {
     private ObjectMapper objectMapper;
     @MockBean
     private AuthService authService;
-    @MockBean
-    JwtAuthInterceptor jwtAuthInterceptor;
-    @MockBean
-    JwtAuthArgumentResolver jwtAuthArgumentResolver;
 
     @DisplayName("로그인을 요청한다.")
     @Test

--- a/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
@@ -1,0 +1,65 @@
+package com.ku.covigator.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ku.covigator.dto.request.PatchMemberRequest;
+import com.ku.covigator.dto.request.PostVerifyNicknameRequest;
+import com.ku.covigator.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ComponentScan({"com.ku.covigator.support", "com.ku.covigator.security.jwt"})
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private MemberService memberService;
+
+    @DisplayName("회원 정보 수정을 요청한다.")
+    @Test
+    void updateMemberInfo() throws Exception {
+        //given
+
+        PatchMemberRequest request = PatchMemberRequest.builder()
+                .nickname("covi")
+                .password("covigator123!")
+                .passwordVerification("covigator123!")
+                .build();
+
+        //when //then
+        mockMvc.perform(patch("/members/{member_id}", 1L)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("닉네임 중복 확인을 요청한다.")
+    @Test
+    void verifyNicknameDuplication() throws Exception {
+        //given
+        PostVerifyNicknameRequest request = new PostVerifyNicknameRequest("covi");
+
+        //when //then
+        mockMvc.perform(post("/members/nickname")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.ku.covigator.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ku.covigator.dto.request.PatchMemberRequest;
 import com.ku.covigator.dto.request.PostVerifyNicknameRequest;

--- a/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.ku.covigator.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ku.covigator.dto.request.PatchMemberRequest;
 import com.ku.covigator.dto.request.PostVerifyNicknameRequest;
@@ -33,7 +34,6 @@ class MemberControllerTest {
     @Test
     void updateMemberInfo() throws Exception {
         //given
-
         PatchMemberRequest request = PatchMemberRequest.builder()
                 .nickname("covi")
                 .password("covigator123!")
@@ -46,6 +46,24 @@ class MemberControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않는 경우 상태코드 400을 반환한다.")
+    @Test
+    void return400WhenPasswordIsNotEqualToPasswordVerification() throws Exception {
+        //given
+        PatchMemberRequest request = PatchMemberRequest.builder()
+                .nickname("covi")
+                .password("covigator123!")
+                .passwordVerification("covi123!")
+                .build();
+
+        //when //then
+        mockMvc.perform(patch("/members/{member_id}", 1L)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @DisplayName("닉네임 중복 확인을 요청한다.")

--- a/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/PlaceControllerTest.java
@@ -1,8 +1,6 @@
 package com.ku.covigator.controller;
 
 import com.ku.covigator.domain.Place;
-import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
-import com.ku.covigator.security.jwt.JwtAuthInterceptor;
 import com.ku.covigator.service.PlaceService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ComponentScan("com.ku.covigator.support")
+@ComponentScan({"com.ku.covigator.support", "com.ku.covigator.security.jwt"})
 @WebMvcTest(controllers = PlaceController.class)
 class PlaceControllerTest {
 
@@ -29,10 +27,6 @@ class PlaceControllerTest {
     private MockMvc mockMvc;
     @MockBean
     private PlaceService placeService;
-    @MockBean
-    JwtAuthInterceptor jwtAuthInterceptor;
-    @MockBean
-    JwtAuthArgumentResolver jwtAuthArgumentResolver;
 
     @DisplayName("장소 세부 정보를 조회한다.")
     @Test

--- a/src/test/java/com/ku/covigator/domain/member/MemberTest.java
+++ b/src/test/java/com/ku/covigator/domain/member/MemberTest.java
@@ -108,4 +108,23 @@ class MemberTest {
         //then
         assertThat(member.getImageUrl()).isEqualTo("www.covi.com");
     }
+
+    @DisplayName("회원 정보를 수정한다.")
+    @Test
+    void updateMemberInfo() {
+        //given
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password("covigator123")
+                .nickname("covi")
+                .platform(Platform.LOCAL)
+                .build();
+
+        //when
+        member.updateMemberInfo("covi2", "covigator123!");
+
+        //then
+        assertThat(member.getNickname()).isEqualTo("covi2");
+        assertThat(member.getPassword()).isEqualTo("covigator123!");
+    }
 }

--- a/src/test/java/com/ku/covigator/service/ChatServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/ChatServiceTest.java
@@ -119,7 +119,9 @@ class ChatServiceTest {
         //then
         Assertions.assertAll(
                 () -> assertThat(response.message()).isEqualTo("여기 좋아요"),
-                () -> assertThat(response.sender()).isEqualTo("김코비")
+                () -> assertThat(response.nickname()).isEqualTo("김코비"),
+                () -> assertThat(response.memberId()).isEqualTo(savedMember.getId()),
+                () -> assertThat(response.profileImageUrl()).isEqualTo(savedMember.getImageUrl())
         );
     }
 

--- a/src/test/java/com/ku/covigator/service/MemberServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/MemberServiceTest.java
@@ -1,0 +1,104 @@
+package com.ku.covigator.service;
+
+import com.ku.covigator.domain.member.Member;
+import com.ku.covigator.domain.member.Platform;
+import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
+import com.ku.covigator.exception.notfound.NotFoundMemberException;
+import com.ku.covigator.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("회원 정보 수정 요청 작업이 정상적으로 실행된다.")
+    @Test
+    void updateMemberInfo() {
+        //given
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password("covigator123!")
+                .nickname("covi")
+                .platform(Platform.LOCAL)
+                .build();
+
+        memberRepository.save(member);
+
+        //when
+        memberService.updateMember(member.getId(), "김코비", "covi123!");
+
+        //then
+        Member updatedMember = memberRepository.findById(member.getId()).get();
+        assertThat(updatedMember.getNickname()).isEqualTo("김코비");
+    }
+
+    @DisplayName("회원 정보 수정 요청 시 중복된 닉네임이 존재하는 경우 예외가 발생한다.")
+    @Test
+    void badRequestExceptionOccursWhenDuplicatedNicknameExistsWhileUpdating() {
+        //given
+        String nickName = "covi";
+
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password("covigator123!")
+                .nickname(nickName)
+                .platform(Platform.LOCAL)
+                .build();
+
+        memberRepository.save(member);
+
+        //when //then
+        assertThatThrownBy(
+                () -> memberService.updateMember(member.getId(), nickName, "covi123!")
+        ).isInstanceOf(DuplicateMemberNicknameException.class);
+    }
+
+    @DisplayName("존재하지 않는 회원에 대한 회원 정보 수정 요청 시 예외가 발생한다.")
+    @Test
+    void notFoundExceptionOccursWhenMemberNotExists() {
+        //when //then
+        assertThatThrownBy(
+                () -> memberService.updateMember(1L, "covi", "covi123!")
+        ).isInstanceOf(NotFoundMemberException.class);
+    }
+
+    @DisplayName("중복된 닉네임이 존재하는 경우 예외가 발생한다.")
+    @Test
+    void badRequestExceptionOccursWhenDuplicatedNicknameExists() {
+        //given
+        String nickName = "covi";
+
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password("covigator123!")
+                .nickname(nickName)
+                .platform(Platform.LOCAL)
+                .build();
+
+        memberRepository.save(member);
+
+        //when //then
+        assertThatThrownBy(
+                () -> memberService.verifyNicknameDuplication(nickName)
+        ).isInstanceOf(DuplicateMemberNicknameException.class);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #58 

## 📝 작업사항

- [x] 회원 정보 수정 기능 구현
- [x] 닉네임 중복 확인 요청 기능 구현
- [x] 테스트 코드 수정
- [x] 리뷰 DTO의 score 최솟값 0으로 수정
- [x] 중첩 DTO 클래스 내부 클래스도 검증될 수 있도록 수정
- [x] 일부 자식 엔티티에 `@OnDelete(action = OnDeleteAction.CASCADE)` 추가