### PR TITLE
[Feat] 카카오/로컬 회원가입 로직 수정

### DIFF
--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -79,4 +79,9 @@ public class Member extends BaseTime {
         this.nickname = nickname;
         this.password = password;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
 }

--- a/src/main/java/com/ku/covigator/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/KakaoUserInfoResponse.java
@@ -8,15 +8,14 @@ import com.ku.covigator.domain.member.Platform;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoUserInfoResponse(KakaoAccount kakaoAccount){
 
-    public record KakaoAccount(String name, String email, Profile profile) {
-        public record Profile (String nickname, String thumbnail_image_url) { }
+    public record KakaoAccount(String email, Profile profile) {
+        public record Profile (String thumbnail_image_url) { }
 
     }
 
     public Member toEntity() {
         return Member.builder()
                 .email(kakaoAccount.email)
-                .nickname(kakaoAccount.profile.nickname)
                 .imageUrl(kakaoAccount.profile.thumbnail_image_url)
                 .password(null)
                 .platform(Platform.KAKAO)

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.security.SecureRandom;
 import java.util.Optional;
 
 
@@ -124,9 +125,10 @@ public class AuthService {
 
     // 신규 닉네임 생성
     private String createRandomNickname() {
+        SecureRandom secureRandom = new SecureRandom();
         String nickname;
         do {
-            nickname = BASE_NICKNAME + (int) (Math.random() * MAX_UID + 1);
+            nickname = BASE_NICKNAME + (secureRandom.nextInt(MAX_UID) + 1);
         } while (isNicknameDuplicated(nickname));
         return nickname;
     }

--- a/src/test/java/com/ku/covigator/domain/member/MemberTest.java
+++ b/src/test/java/com/ku/covigator/domain/member/MemberTest.java
@@ -127,4 +127,19 @@ class MemberTest {
         assertThat(member.getNickname()).isEqualTo("covi2");
         assertThat(member.getPassword()).isEqualTo("covigator123!");
     }
+
+    @DisplayName("회원 닉네임을 변경한다.")
+    @Test
+    void updateNickname() {
+        //given
+        Member member = Member.builder()
+                .nickname("covi")
+                .build();
+
+        //when
+        member.updateNickname("covi2");
+
+        //then
+        assertThat(member.getNickname()).isEqualTo("covi2");
+    }
 }

--- a/src/test/java/com/ku/covigator/security/kakao/KakaoOauthProviderTest.java
+++ b/src/test/java/com/ku/covigator/security/kakao/KakaoOauthProviderTest.java
@@ -49,8 +49,8 @@ class KakaoOauthProviderTest {
 
         KakaoUserInfoResponse response =
                 new KakaoUserInfoResponse(
-                        new KakaoUserInfoResponse.KakaoAccount("name", kakaoEmail,
-                                new KakaoUserInfoResponse.KakaoAccount.Profile("nickname", "image")));
+                        new KakaoUserInfoResponse.KakaoAccount(kakaoEmail,
+                                new KakaoUserInfoResponse.KakaoAccount.Profile("image")));
 
         server.expect(requestTo(KAKAO_USER_INFO_URL))
                 .andExpect(content().contentType("application/x-www-form-urlencoded"))

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -252,8 +252,8 @@ class AuthServiceTest {
 
         KakaoUserInfoResponse userInfoResponse =
                 new KakaoUserInfoResponse(
-                        new KakaoUserInfoResponse.KakaoAccount("name", email,
-                                new KakaoUserInfoResponse.KakaoAccount.Profile("nickname", "image")));
+                        new KakaoUserInfoResponse.KakaoAccount(email,
+                                new KakaoUserInfoResponse.KakaoAccount.Profile("image")));
         given(kakaoOauthProvider.getKakaoUserInfo(any())).willReturn(userInfoResponse);
 
         //when
@@ -283,8 +283,8 @@ class AuthServiceTest {
 
         KakaoUserInfoResponse userInfoResponse =
                 new KakaoUserInfoResponse(
-                        new KakaoUserInfoResponse.KakaoAccount("name", email,
-                                new KakaoUserInfoResponse.KakaoAccount.Profile("nickname", "image")));
+                        new KakaoUserInfoResponse.KakaoAccount(email,
+                                new KakaoUserInfoResponse.KakaoAccount.Profile("image")));
         given(kakaoOauthProvider.getKakaoUserInfo(any())).willReturn(userInfoResponse);
 
         //when
@@ -303,8 +303,8 @@ class AuthServiceTest {
 
         KakaoUserInfoResponse userInfoResponse =
                 new KakaoUserInfoResponse(
-                        new KakaoUserInfoResponse.KakaoAccount("name", "email",
-                                new KakaoUserInfoResponse.KakaoAccount.Profile("nickname", "image")));
+                        new KakaoUserInfoResponse.KakaoAccount("email",
+                                new KakaoUserInfoResponse.KakaoAccount.Profile("image")));
         given(kakaoOauthProvider.getKakaoUserInfo(any())).willReturn(userInfoResponse);
 
         //when
@@ -313,4 +313,5 @@ class AuthServiceTest {
         //then
         assertThat(response.isNew()).isEqualTo("True");
     }
+
 }


### PR DESCRIPTION
## 📝 작업사항

- [x] 로컬 회원가입 시 닉네임 중복 검증 로직 추가
- [x] 카카오 회원가입 시 카카오에 등록된 이름, 닉네임 정보는 사용하지 않도록 변경
- [x] 카카오 회원가입 시 `코비게이터 + (1 ~ 99999 사이 난수값)`의 랜덤 닉네임으로 저장되도록 구현

## 주의사항

- 생성한 랜덤 닉네임이 이미 존재하는 경우 닉네임을 다시 생성하도록 구현한다.