### PR TITLE
[Feat] 비밀번호 찾기 - 이메일 인증 & 비밀번호 변경 기능 구현 (with Redis-Elasticache & AWS SES)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: 7.2.5
+
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,9 @@ dependencies {
 
 	//amazon ses
 	implementation 'com.amazonaws:aws-java-sdk-ses:1.12.772'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ def jacocoExcludePatterns = [
 		"**/security/*",
 		"**/support/*",
 		"**/dto/*",
-		"**/*ControllerAdvice*"
+		"**/*ControllerAdvice*",
+		"**/common/*",
+		"**/*SESService*"
 ]
 
 
@@ -39,7 +41,7 @@ sonar {
 		property 'sonar.sources', 'src'
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**, **/*ControllerAdvice*'
+		property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*, **/config/**, **/exception/**, **/dto/**, **/security/**, **/support/**, **/*ControllerAdvice*, **/common/*, **/*SESService*'
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'
 		property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile
@@ -97,6 +99,9 @@ dependencies {
 
 	// mongoDB
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+	//amazon ses
+	implementation 'com.amazonaws:aws-java-sdk-ses:1.12.772'
 }
 
 tasks.named('test') {
@@ -139,14 +144,14 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = 'LINE'
 				value = 'COVEREDRATIO'
-				minimum = 0.60
+				minimum = 0.70
 			}
 
 			// 브랜치 커버리지를 최소 70% 만족
 			limit {
 				counter = 'BRANCH'
 				value = 'COVEREDRATIO'
-				minimum = 0.60
+				minimum = 0.70
 			}
 
 			excludes = jacocoExcludePatterns

--- a/src/main/java/com/ku/covigator/common/EmailVerificationTemplate.java
+++ b/src/main/java/com/ku/covigator/common/EmailVerificationTemplate.java
@@ -9,7 +9,7 @@ public enum EmailVerificationTemplate {
 
     SUBJECT("[Covigator] 비밀번호 찾기 인증번호입니다."),
     CONTENT_PREFIX("인증번호는 "),
-    CONTENT_SUFFIX(" 입니다.\n인증번호의 유효 기간은 10분 입니다.");
+    CONTENT_SUFFIX(" 입니다.\n인증번호의 유효 기간은 5분 입니다.");
 
     private final String text;
 

--- a/src/main/java/com/ku/covigator/common/EmailVerificationTemplate.java
+++ b/src/main/java/com/ku/covigator/common/EmailVerificationTemplate.java
@@ -1,0 +1,16 @@
+package com.ku.covigator.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmailVerificationTemplate {
+
+    SUBJECT("[Covigator] 비밀번호 찾기 인증번호입니다."),
+    CONTENT_PREFIX("인증번호는 "),
+    CONTENT_SUFFIX(" 입니다.\n인증번호의 유효 기간은 10분 입니다.");
+
+    private final String text;
+
+}

--- a/src/main/java/com/ku/covigator/config/RedisConfig.java
+++ b/src/main/java/com/ku/covigator/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.ku.covigator.config;
+
+import com.ku.covigator.config.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<Object, Object> redisTemplate() {
+        RedisTemplate<Object, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+}

--- a/src/main/java/com/ku/covigator/config/SESConfig.java
+++ b/src/main/java/com/ku/covigator/config/SESConfig.java
@@ -1,0 +1,28 @@
+package com.ku.covigator.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import com.ku.covigator.config.properties.AwsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SESConfig {
+
+    private final AwsProperties awsProperties;
+
+    @Bean
+    public AmazonSimpleEmailService amazonSimpleEmailService() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(awsProperties.getAccessKey(), awsProperties.getSecretKey());
+
+        return AmazonSimpleEmailServiceClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(awsProperties.getRegion())
+                .build();
+    }
+}

--- a/src/main/java/com/ku/covigator/config/properties/RedisProperties.java
+++ b/src/main/java/com/ku/covigator/config/properties/RedisProperties.java
@@ -1,0 +1,15 @@
+package com.ku.covigator.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties("spring.data.redis")
+public class RedisProperties {
+
+    private final String host;
+    private final int port;
+
+}

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.ku.covigator.controller;
 
+import com.ku.covigator.dto.request.FindPasswordRequest;
 import com.ku.covigator.dto.request.PostSignInRequest;
 import com.ku.covigator.dto.request.PostSignUpRequest;
 import com.ku.covigator.dto.response.AccessTokenResponse;
@@ -34,6 +35,13 @@ public class AuthController {
                                                       @RequestPart(value = "image", required = false) MultipartFile image) {
         String accessToken = authService.signUp(request.toEntity(), image);
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
+    }
+
+    @Operation(summary = "비밀번호 찾기 (임시 비밀번호 설정)")
+    @PostMapping("/find-password")
+    public ResponseEntity<Void> findPassword(@Valid @RequestBody FindPasswordRequest request) {
+        authService.createVerificationNumber(request.email());
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "카카오 로그인 (카카오 서버 Redirect 용, 프론트에서 호출하지 않음)")

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -57,8 +57,8 @@ public class AuthController {
     @Operation(summary = "이메일 인증번호 인증")
     @PostMapping("/verify-code")
     public ResponseEntity<Void> verifyNumber(@Valid @RequestBody VerifyCodeRequest request) {
-        String key = redisUtil.getData(request.email());
-        if(!key.equals(request.code())) {
+        String code = redisUtil.getData(request.email());
+        if(!code.equals(request.code())) {
             throw new WrongVerificationCodeException();
         }
         return ResponseEntity.ok().build();

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.ku.covigator.controller;
 
+import com.ku.covigator.dto.request.ChangePasswordRequest;
 import com.ku.covigator.dto.request.FindPasswordRequest;
 import com.ku.covigator.dto.request.PostSignInRequest;
 import com.ku.covigator.dto.request.PostSignUpRequest;
 import com.ku.covigator.dto.response.AccessTokenResponse;
+import com.ku.covigator.dto.response.ErrorResponse;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
+import com.ku.covigator.exception.badrequest.WrongVerificationCodeException;
 import com.ku.covigator.service.AuthService;
+import com.ku.covigator.service.RedisUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AuthController {
 
     private final AuthService authService;
+    private final RedisUtil redisUtil;
 
     @Operation(summary = "로컬 로그인")
     @PostMapping("/sign-in")
@@ -37,6 +42,12 @@ public class AuthController {
         return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
     }
 
+    @Operation(summary = "카카오 로그인 (카카오 서버 Redirect 용, 프론트에서 호출하지 않음)")
+    @GetMapping("/oauth/kakao")
+    public ResponseEntity<KakaoSignInResponse> signInKakao(@RequestParam String code) {
+        return ResponseEntity.ok(authService.signInKakao(code));
+    }
+
     @Operation(summary = "비밀번호 찾기 (임시 비밀번호 설정)")
     @PostMapping("/find-password")
     public ResponseEntity<Void> findPassword(@Valid @RequestBody FindPasswordRequest request) {
@@ -44,10 +55,13 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "카카오 로그인 (카카오 서버 Redirect 용, 프론트에서 호출하지 않음)")
-    @GetMapping("/oauth/kakao")
-    public ResponseEntity<KakaoSignInResponse> signInKakao(@RequestParam String code) {
-        return ResponseEntity.ok(authService.signInKakao(code));
+    @Operation(summary = "이메일 인증번호 인증")
+    @PostMapping("/verify-code")
+    public ResponseEntity<Void> verifyNumber(@RequestParam String code) {
+        if(!redisUtil.existData(code)) {
+            throw new WrongVerificationCodeException();
+        };
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/ku/covigator/controller/MemberController.java
+++ b/src/main/java/com/ku/covigator/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
     }
 
     @Operation(summary = "닉네임 중복 확인")
-    @PostMapping("/nickname")
+    @PostMapping("/check-for-duplicate/nickname")
     public ResponseEntity<Void> verifyNickname(
             @Valid @RequestBody PostVerifyNicknameRequest request
     ) {

--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -59,8 +59,8 @@ public class Member extends BaseTime {
         this.platform = platform;
     }
 
-    public void encodePassword(String encodedPassword) {
-        this.password = encodedPassword;
+    public void savePassword(String password) {
+        this.password = password;
     }
 
     public void putTravelStyle(TravelStyle travelStyle) {

--- a/src/main/java/com/ku/covigator/dto/EmailSenderDto.java
+++ b/src/main/java/com/ku/covigator/dto/EmailSenderDto.java
@@ -1,0 +1,28 @@
+package com.ku.covigator.dto;
+
+import com.amazonaws.services.simpleemail.model.*;
+import lombok.Builder;
+
+@Builder
+public record EmailSenderDto(String receiver, String subject, String content) {
+
+    private static final String FROM = "admin@covigator.shop";
+
+    public SendEmailRequest toSendRequestDto() {
+
+        Destination destination = new Destination().withToAddresses(receiver);
+        Message message = new Message()
+                .withSubject(createContent(subject))
+                .withBody(new Body().withHtml(createContent(content)));
+        return new SendEmailRequest()
+                .withSource(FROM)
+                .withDestination(destination)
+                .withMessage(message);
+    }
+
+    private Content createContent(String text) {
+        return new Content()
+                .withCharset("UTF-8")
+                .withData(text);
+    }
+}

--- a/src/main/java/com/ku/covigator/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,10 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequest(
+        @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
+                message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String password,
+        @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
+                message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String passwordVerification) {
+}

--- a/src/main/java/com/ku/covigator/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/FindPasswordRequest.java
@@ -1,0 +1,6 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record FindPasswordRequest(@Email(message = "올바른 이메일 형식이 아닙니다.") String email) {
+}

--- a/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostCourseRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ku.covigator.domain.Course;
 import com.ku.covigator.domain.CoursePlace;
 import com.ku.covigator.domain.member.Member;
-import com.ku.covigator.support.GeometryUtils;
+import com.ku.covigator.support.GeometryUtil;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -58,7 +58,7 @@ public record PostCourseRequest(
                         .description(placeDto.description)
                         .address(placeDto.address)
                         .course(course)
-                        .coordinate(GeometryUtils.generatePoint(placeDto.latitude, placeDto.longitude))
+                        .coordinate(GeometryUtil.generatePoint(placeDto.latitude, placeDto.longitude))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/ku/covigator/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/VerifyCodeRequest.java
@@ -1,0 +1,9 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record VerifyCodeRequest(
+        @Email(message = "올바른 이메일 형식이 아닙니다.") String email,
+        @NotEmpty(message = "공백일 수 없습니다.") String code ) {
+}

--- a/src/main/java/com/ku/covigator/exception/badrequest/WrongVerificationCodeException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/WrongVerificationCodeException.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.exception.badrequest;
+
+public class WrongVerificationCodeException extends BadRequestException{
+
+    public WrongVerificationCodeException() {
+        super(3005, "인증번호가 올바르지 않습니다. 다시 시도해주세요.");
+    }
+}

--- a/src/main/java/com/ku/covigator/exception/notfound/NotFoundEmailException.java
+++ b/src/main/java/com/ku/covigator/exception/notfound/NotFoundEmailException.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.exception.notfound;
+
+public class NotFoundEmailException extends NotFoundException{
+
+    public NotFoundEmailException() {
+        super(1004, "등록되지 않은 이메일입니다.");
+    }
+}

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -110,7 +110,7 @@ public class AuthService {
     public void createVerificationNumber(String email) {
 
         // 등록된 이메일인지 확인
-        memberRepository.findByEmailAndPlatform(email, Platform.LOCAL)
+        Member member = memberRepository.findByEmailAndPlatform(email, Platform.LOCAL)
                 .orElseThrow(NotFoundEmailException::new);
 
         // 인증번호 생성
@@ -119,10 +119,10 @@ public class AuthService {
         // 이메일 전송
         sesService.sendEmail(SUBJECT.getText(),
                 CONTENT_PREFIX.getText() + verificationNumber + CONTENT_SUFFIX.getText(),
-                email);
+                member.getEmail());
 
         // Redis에 인증번호 저장
-        redisUtil.setDataExpire(email, verificationNumber, 60 * 5L);
+        redisUtil.setDataExpire(member.getEmail(), verificationNumber, 60 * 5L);
 
     }
 

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -60,7 +60,7 @@ public class AuthService {
 
         // 패스워드 인코딩
         String encodedPassword = passwordEncoder.encode(member.getPassword());
-        member.encodePassword(encodedPassword);
+        member.savePassword(encodedPassword);
 
         // S3에 프로필 이미지 업로드
         if (image != null && !image.isEmpty()) {
@@ -124,6 +124,18 @@ public class AuthService {
         // Redis에 인증번호 저장
         redisUtil.setDataExpire(email, verificationNumber, 60 * 5L);
 
+    }
+
+    // 비밀번호 변경
+    public void changePassword(Long memberId, String password) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        String encodedPassword = passwordEncoder.encode(password);
+        member.savePassword(encodedPassword);
+
+        memberRepository.save(member);
     }
 
     // 닉네임 중복 검증

--- a/src/main/java/com/ku/covigator/service/RedisUtil.java
+++ b/src/main/java/com/ku/covigator/service/RedisUtil.java
@@ -1,0 +1,30 @@
+package com.ku.covigator.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final StringRedisTemplate template;
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(template.hasKey(key));
+    }
+
+    public void deleteData(String key) {
+        template.delete(key);
+    }
+
+}

--- a/src/main/java/com/ku/covigator/service/RedisUtil.java
+++ b/src/main/java/com/ku/covigator/service/RedisUtil.java
@@ -19,6 +19,11 @@ public class RedisUtil {
         valueOperations.set(key, value, expireDuration);
     }
 
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        return valueOperations.get(key);
+    }
+
     public boolean existData(String key) {
         return Boolean.TRUE.equals(template.hasKey(key));
     }

--- a/src/main/java/com/ku/covigator/service/SESService.java
+++ b/src/main/java/com/ku/covigator/service/SESService.java
@@ -1,0 +1,34 @@
+package com.ku.covigator.service;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.SendEmailResult;
+import com.ku.covigator.dto.EmailSenderDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SESService {
+
+    private final AmazonSimpleEmailService amazonSimpleEmailService;
+
+    @Async
+    public void sendEmail(String subject, String content, String receiver) {
+
+        EmailSenderDto senderDto = EmailSenderDto.builder()
+                .receiver(receiver)
+                .subject(subject)
+                .content(content)
+                .build();
+
+        SendEmailResult sendEmailResult = amazonSimpleEmailService.sendEmail(senderDto.toSendRequestDto());
+
+        if(sendEmailResult.getSdkHttpMetadata().getHttpStatusCode() != 200) {
+            log.error("{}", sendEmailResult.getSdkResponseMetadata().toString());
+        }
+    }
+
+}

--- a/src/main/java/com/ku/covigator/support/GeometryUtil.java
+++ b/src/main/java/com/ku/covigator/support/GeometryUtil.java
@@ -4,7 +4,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
-public class GeometryUtils {
+public class GeometryUtil {
 
     private static final GeometryFactory geometryFactory = new GeometryFactory();
 

--- a/src/main/java/com/ku/covigator/support/RandomUtil.java
+++ b/src/main/java/com/ku/covigator/support/RandomUtil.java
@@ -2,7 +2,7 @@ package com.ku.covigator.support;
 
 import java.security.SecureRandom;
 
-public class RandomUtils {
+public class RandomUtil {
 
     private static final SecureRandom random = new SecureRandom();
 

--- a/src/main/java/com/ku/covigator/support/RandomUtils.java
+++ b/src/main/java/com/ku/covigator/support/RandomUtils.java
@@ -1,0 +1,28 @@
+package com.ku.covigator.support;
+
+import java.security.SecureRandom;
+
+public class RandomUtils {
+
+    private static final SecureRandom random = new SecureRandom();
+
+    public static String generateRandomMixStr(int length) {
+
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%&";
+        StringBuilder sb = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(characters.length());
+            sb.append(characters.charAt(index));
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * return 1 ~ range
+     */
+    public static int generateRandomNumber(int range) {
+        return (random.nextInt(range) + 1);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,9 @@ spring:
     mongodb:
       uri: ${MONGO_DB_URI}
       database: ${MONGO_DB_DATABASE}
+    redis:
+      host: localhost
+      port: 6379
 
 security:
   jwt:

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.ku.covigator.controller;
 
+import com.ku.covigator.dto.request.FindPasswordRequest;
 import com.ku.covigator.dto.request.PostSignUpRequest;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.dto.request.PostSignInRequest;
@@ -119,6 +120,22 @@ class AuthControllerTest {
                         status().isOk(),
                         jsonPath("$.access_token").value("token"),
                         jsonPath("$.is_new").value("False")
+                );
+    }
+
+    @DisplayName("비밀번호 찾기를 요청한다.")
+    @Test
+    void findPassword() throws Exception {
+        //given
+        FindPasswordRequest request = new FindPasswordRequest("covi@naver.com");
+
+        //when //then
+        mockMvc.perform(post("/accounts/find-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpectAll(
+                        status().isOk()
                 );
     }
 

--- a/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
@@ -72,7 +72,7 @@ class MemberControllerTest {
         PostVerifyNicknameRequest request = new PostVerifyNicknameRequest("covi");
 
         //when //then
-        mockMvc.perform(post("/members/nickname")
+        mockMvc.perform(post("/members/check-for-duplicate/nickname")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -38,6 +38,8 @@ class AuthServiceTest {
     PasswordEncoder passwordEncoder;
     @Autowired
     JwtProvider jwtProvider;
+    @Autowired
+    RedisUtil redisUtil;
     @MockBean
     KakaoOauthProvider kakaoOauthProvider;
     @MockBean
@@ -353,6 +355,27 @@ class AuthServiceTest {
         assertThatThrownBy(
                 () -> authService.createVerificationNumber("covi@naver.com")
         ).isInstanceOf(NotFoundEmailException.class);
+    }
+
+    @DisplayName("인증번호 생성시 Redis에 인증번호가 정상적으로 저장된다.")
+    @Test
+    void verificationCodeSavedInRedis() {
+        //given
+        String email = "covi@naver.com";
+        Member member = Member.builder()
+                .email(email)
+                .password("covigator123")
+                .nickname("covi")
+                .imageUrl("www.covi.com")
+                .platform(Platform.LOCAL)
+                .build();
+        memberRepository.save(member);
+
+        //when
+        authService.createVerificationNumber(email);
+
+        //then
+        assertThat(redisUtil.existData(email)).isTrue();
     }
 
 }

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import com.ku.covigator.dto.response.KakaoTokenResponse;
 import com.ku.covigator.dto.response.KakaoUserInfoResponse;
 import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
 import com.ku.covigator.exception.badrequest.PasswordMismatchException;
+import com.ku.covigator.exception.notfound.NotFoundEmailException;
 import com.ku.covigator.exception.notfound.NotFoundMemberException;
 import com.ku.covigator.repository.MemberRepository;
 import com.ku.covigator.security.jwt.JwtProvider;
@@ -343,6 +344,15 @@ class AuthServiceTest {
 
         //then
         assertThat(response.isNew()).isEqualTo("True");
+    }
+
+    @DisplayName("등록되지 않은 이메일에 대한 인증번호 발송 요청시 예외가 발생한다.")
+    @Test
+    void notFoundEmailExceptionOccursWhenMemberIsNotRegistered() {
+        //when //then
+        assertThatThrownBy(
+                () -> authService.createVerificationNumber("covi@naver.com")
+        ).isInstanceOf(NotFoundEmailException.class);
     }
 
 }

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -378,4 +378,35 @@ class AuthServiceTest {
         assertThat(redisUtil.existData(email)).isTrue();
     }
 
+    @DisplayName("등록되지 않은 사용자에 대한 비밀번호 변경 요청시 예외가 발생한다.")
+    @Test
+    void changePasswordFailsWhenMemberIsNotFound() {
+        //when //then
+        assertThatThrownBy(
+                () -> authService.changePassword(1L, "covi123!")
+        );
+    }
+
+    @DisplayName("비밀번호를 변경한다.")
+    @Test
+    void changePassword() {
+        //given
+        String oldPassword = "covigator1!";
+        Member member = Member.builder()
+                .email("covi@naver.com")
+                .password(oldPassword)
+                .nickname("covi")
+                .imageUrl("www.covi.com")
+                .platform(Platform.LOCAL)
+                .build();
+        Member savedMember = memberRepository.save(member);
+
+        //when
+        authService.changePassword(savedMember.getId(), "covi123!");
+
+        //then
+        String newPassword = memberRepository.findById(savedMember.getId()).get().getPassword();
+        assertThat(oldPassword).isNotEqualTo(newPassword);
+    }
+
 }

--- a/src/test/java/com/ku/covigator/service/CourseServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/CourseServiceTest.java
@@ -15,7 +15,7 @@ import com.ku.covigator.repository.CoursePlaceRepository;
 import com.ku.covigator.repository.CourseRepository;
 import com.ku.covigator.repository.DibsRepository;
 import com.ku.covigator.repository.MemberRepository;
-import com.ku.covigator.support.GeometryUtils;
+import com.ku.covigator.support.GeometryUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -401,7 +401,7 @@ class CourseServiceTest {
                 .name("가츠시")
                 .description("공대생 추천 맛집")
                 .category("식당")
-                .coordinate(GeometryUtils.generatePoint(1.1,2.2))
+                .coordinate(GeometryUtil.generatePoint(1.1,2.2))
                 .build();
 
         CoursePlace place2 = CoursePlace.builder()
@@ -410,7 +410,7 @@ class CourseServiceTest {
                 .name("레스티오")
                 .description("공대생 추천 카페")
                 .category("카페")
-                .coordinate(GeometryUtils.generatePoint(3.3,4.4))
+                .coordinate(GeometryUtil.generatePoint(3.3,4.4))
                 .build();
         coursePlaceRepository.saveAll(List.of(place, place2));
 

--- a/src/test/java/com/ku/covigator/service/RedisUtilTest.java
+++ b/src/test/java/com/ku/covigator/service/RedisUtilTest.java
@@ -26,6 +26,19 @@ class RedisUtilTest {
         assertThat(redisUtil.existData("key")).isTrue();
     }
 
+    @DisplayName("Redis에 저장된 데이터를 조회할 수 있다.")
+    @Test
+    void getDataFromRedis() {
+        //given
+        redisUtil.setDataExpire("key","value", 60);
+
+        //when
+        String data = redisUtil.getData("key");
+
+        //then
+        assertThat(data).isEqualTo("value");
+    }
+
     @DisplayName("Redis에 저장된 데이터를 삭제할 수 있다.")
     @Test
     void test() {

--- a/src/test/java/com/ku/covigator/service/RedisUtilTest.java
+++ b/src/test/java/com/ku/covigator/service/RedisUtilTest.java
@@ -1,0 +1,54 @@
+package com.ku.covigator.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+class RedisUtilTest {
+
+    @Autowired
+    private RedisUtil redisUtil;
+
+    @DisplayName("Redis에 데이터를 저장할 수 있다.")
+    @Test
+    void saveTest() {
+        //when
+        redisUtil.setDataExpire("key","value", 60);
+
+        //then
+        assertThat(redisUtil.existData("key")).isTrue();
+    }
+
+    @DisplayName("Redis에 저장된 데이터를 삭제할 수 있다.")
+    @Test
+    void test() {
+        //given
+        redisUtil.setDataExpire("key","value", 60 * 10);
+
+        //when
+        redisUtil.deleteData("key");
+
+        //then
+        assertThat(redisUtil.existData("key")).isFalse();
+    }
+
+    @DisplayName("Redis에 저장된 데이터는 만료시간이 지나면 삭제된다.")
+    @Test
+    void expiredTest() {
+        //given
+        redisUtil.setDataExpire("key", "value", 1L);
+
+        //when //then
+        await().pollDelay(Duration.ofSeconds(2)).untilAsserted(
+                () -> assertThat(redisUtil.existData("key")).isFalse()
+        );
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #61

## 📝 작업사항

### API

- 비밀번호 찾기 요청 API
- 이메일 인증번호 인증 API
- 비밀번호 변경 API

### 기능 구현
- [x] 이메일 인증번호 발송 로직 구현
- [x] 인증번호 저장 로직 구현 - `Redis`
- [x] 비밀번호 변경 로직 구현 (올바른 인증번호를 입력한 경우)

### 인프라
- [x] `AWS SES` 생성 및 연동
- [x] `AWS SES` 샌드박스 해제
- [x] `ElastiCache` 생성 및 연동

## 🚨 주의사항
- 로컬 서버에서는 `ElasticCache`를 사용할 수 없다. 따라서 `application.yml`의 Redis host는 `localhost`로 지정하여 로컬에서 실행되는 `Redis`에 연결할 수 있도록 한다.
- ***인증번호 유효기간: 5분***