### PR TITLE
[Fix] 채팅 기록 저장시 서울 시간으로 저장되도록 수정

### DIFF
--- a/src/main/java/com/ku/covigator/domain/Chat.java
+++ b/src/main/java/com/ku/covigator/domain/Chat.java
@@ -15,16 +15,16 @@ public class Chat {
     @Id
     private String id;
     private Long courseId;
-    private String timestamp;
+    private String time;
     private String nickname;
     private String profileImageUrl;
     private Long memberId;
     private String message;
 
     @Builder
-    public Chat(Long courseId, String timestamp, String nickname, String message, String profileImageUrl, Long memberId) {
+    public Chat(Long courseId, String time, String nickname, String message, String profileImageUrl, Long memberId) {
         this.courseId = courseId;
-        this.timestamp = timestamp;
+        this.time = time;
         this.nickname = nickname;
         this.message = message;
         this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
@@ -17,7 +17,7 @@ public record GetChatHistoryResponse(Long myId, List<ChatDto> chat) {
                 .map(chat -> ChatDto.builder()
                         .nickname(chat.getNickname())
                         .message(chat.getMessage())
-                        .timestamp(chat.getTimestamp())
+                        .timestamp(chat.getTime())
                         .profileImageUrl(chat.getProfileImageUrl())
                         .memberId(chat.getMemberId())
                         .build()

--- a/src/main/java/com/ku/covigator/repository/ChatRepository.java
+++ b/src/main/java/com/ku/covigator/repository/ChatRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface ChatRepository extends MongoRepository<Chat, Long> {
 
-    public List<Chat> findChatByCourseIdOrderByTimestampAsc(Long courseId);
+    public List<Chat> findChatByCourseIdOrderByTimeAsc(Long courseId);
 }

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -12,9 +12,7 @@ import com.ku.covigator.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -29,7 +27,7 @@ public class ChatService {
     public List<Chat> getChatHistory(Long courseId) {
 
         Course course = courseRepository.findById(courseId).orElseThrow(NotFoundCourseException::new);
-        return chatRepository.findChatByCourseIdOrderByTimestampAsc(course.getId());
+        return chatRepository.findChatByCourseIdOrderByTimeAsc(course.getId());
     }
 
     public SaveMessageResponse saveMessage(Long memberId, Long courseId, String message) {

--- a/src/main/java/com/ku/covigator/service/ChatService.java
+++ b/src/main/java/com/ku/covigator/service/ChatService.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -48,7 +51,7 @@ public class ChatService {
         return Chat.builder()
                 .message(message)
                 .nickname(member.getNickname())
-                .timestamp(String.valueOf(new Timestamp(System.currentTimeMillis())))
+                .time(String.valueOf(LocalDateTime.now(ZoneId.of("Asia/Seoul"))))
                 .courseId(courseId)
                 .memberId(member.getId())
                 .profileImageUrl(member.getImageUrl())

--- a/src/test/java/com/ku/covigator/service/ChatServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/ChatServiceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -53,18 +53,18 @@ class ChatServiceTest {
                 .build();
         Course savedCourse = courseRepository.save(course);
 
-        String time = new Timestamp(System.currentTimeMillis()).toString();
+        String time = LocalDateTime.now().toString();
         Chat chat = Chat.builder()
                 .courseId(savedCourse.getId())
-                .timestamp(time)
+                .time(time)
                 .nickname("김코비")
                 .message("여기 좋아요")
                 .build();
 
-        String time2 = new Timestamp(System.currentTimeMillis()).toString();
+        String time2 = LocalDateTime.now().toString();
         Chat chat2 = Chat.builder()
                 .courseId(savedCourse.getId())
-                .timestamp(time2)
+                .time(time2)
                 .nickname("박코비")
                 .message("저는 별로,,")
                 .build();


### PR DESCRIPTION
## 🐛 버그

- 채팅 로그 저장 시간이 `UTC`를 기준으로 설정되어 9시간 이른 시각으로 저장되는 문제 발생

## 📝 작업사항

- 채팅 로그 저장 시간이`Asia/Seoul`을 기준으로 설정되도록 Timezone 설정