### PR TITLE
[Feat] Refresh Token Rotation 적용

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,6 +51,7 @@ jobs:
           MONGO_DB_URI: ${{ secrets.MONGO_DB_URI }}
           MONGO_DB_DATABASE: ${{ secrets.MONGO_DB_DATABASE }}
           WEATHER_SERVICE_KEY: ${{ secrets.WEATHER_SERVICE_KEY }}
+          RTK_EXPIRATION_LENGTH: ${{ secrets.RTK_EXPIRATION_LENGTH }}
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}

--- a/src/main/java/com/ku/covigator/config/properties/RtrProperties.java
+++ b/src/main/java/com/ku/covigator/config/properties/RtrProperties.java
@@ -1,0 +1,12 @@
+package com.ku.covigator.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties("security.rtr")
+public class RtrProperties {
+    private final long expirationLength;
+}

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -72,4 +72,10 @@ public class AuthController {
         authService.changePassword(memberId, request.password());
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "액세스/리프레시 토큰 재발급")
+    @PostMapping("/reissue-token")
+    public ResponseEntity<TokenResponse> reissueToken(@Valid @RequestBody PostReissueTokenRequest request) {
+        return ResponseEntity.ok(authService.reissueToken(request.refreshToken()));
+    }
 }

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.request.*;
-import com.ku.covigator.dto.response.AccessTokenResponse;
+import com.ku.covigator.dto.response.TokenResponse;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.exception.badrequest.PasswordVerificationException;
 import com.ku.covigator.exception.badrequest.WrongVerificationCodeException;
@@ -28,20 +28,18 @@ public class AuthController {
 
     @Operation(summary = "로컬 로그인")
     @PostMapping("/sign-in")
-    public ResponseEntity<AccessTokenResponse> signIn(@RequestBody @Valid PostSignInRequest request) {
-        String accessToken = authService.signIn(request.email(), request.password());
-        return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
+    public ResponseEntity<TokenResponse> signIn(@RequestBody @Valid PostSignInRequest request) {
+        return ResponseEntity.ok(authService.signIn(request.email(), request.password()));
     }
 
     @Operation(summary = "회원가입")
     @PostMapping("/sign-up")
-    public ResponseEntity<AccessTokenResponse> signUp(@RequestPart(value = "postSignUpRequest") @Valid PostSignUpRequest request,
-                                                      @RequestPart(value = "image", required = false) MultipartFile image) {
-        String accessToken = authService.signUp(request.toEntity(), image);
-        return ResponseEntity.ok(AccessTokenResponse.from(accessToken));
+    public ResponseEntity<TokenResponse> signUp(@RequestPart(value = "postSignUpRequest") @Valid PostSignUpRequest request,
+                                                @RequestPart(value = "image", required = false) MultipartFile image) {
+        return ResponseEntity.ok(authService.signUp(request.toEntity(), image));
     }
 
-    @Operation(summary = "카카오 로그인 (카카오 서버 Redirect 용, 프론트에서 호출하지 않음)")
+    @Operation(summary = "카카오 로그인 (인가 코드 확인)")
     @GetMapping("/oauth/kakao")
     public ResponseEntity<KakaoSignInResponse> signInKakao(@RequestParam String code) {
         return ResponseEntity.ok(authService.signInKakao(code));

--- a/src/main/java/com/ku/covigator/dto/request/PostReissueTokenRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostReissueTokenRequest.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PostReissueTokenRequest(
+
+        @NotNull(message = "NULL일 수 없습니다.") String refreshToken) {
+}

--- a/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/GetChatHistoryResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record GetChatHistoryResponse(Long myId, List<ChatDto> chat) {
 
     @Builder
-    public record ChatDto(String nickname, String timestamp, String message, String profileImageUrl, Long memberId) {
+    public record ChatDto(String nickname, String time, String message, String profileImageUrl, Long memberId) {
     }
 
     public static GetChatHistoryResponse from(Long myId, List<Chat> chatList) {
@@ -17,7 +17,7 @@ public record GetChatHistoryResponse(Long myId, List<ChatDto> chat) {
                 .map(chat -> ChatDto.builder()
                         .nickname(chat.getNickname())
                         .message(chat.getMessage())
-                        .timestamp(chat.getTime())
+                        .time(chat.getTime())
                         .profileImageUrl(chat.getProfileImageUrl())
                         .memberId(chat.getMemberId())
                         .build()

--- a/src/main/java/com/ku/covigator/dto/response/KakaoSignInResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/KakaoSignInResponse.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoSignInResponse(String accessToken, String isNew) {
+public record KakaoSignInResponse(String accessToken, String isNew, String refreshToken) {
 
-    public static KakaoSignInResponse fromNewMember(String accessToken) {
-        return new KakaoSignInResponse(accessToken, "True");
+    public static KakaoSignInResponse fromNewMember(String accessToken, String refreshToken) {
+        return new KakaoSignInResponse(accessToken, "True", refreshToken);
     }
 
-    public static KakaoSignInResponse fromOldMember(String accessToken) {
-        return new KakaoSignInResponse(accessToken, "False");
+    public static KakaoSignInResponse fromOldMember(String accessToken, String refreshToken) {
+        return new KakaoSignInResponse(accessToken, "False", refreshToken);
     }
 
 }

--- a/src/main/java/com/ku/covigator/dto/response/TokenResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/TokenResponse.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record AccessTokenResponse(String accessToken) {
+public record TokenResponse(String accessToken, String refreshToken) {
 
-    public static AccessTokenResponse from(final String accessToken) {
-        return new AccessTokenResponse(accessToken);
+    public static TokenResponse from(final String accessToken, final String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/ku/covigator/exception/badrequest/InvalidRefreshTokenException.java
+++ b/src/main/java/com/ku/covigator/exception/badrequest/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.ku.covigator.exception.badrequest;
+
+public class InvalidRefreshTokenException extends BadRequestException{
+
+    public InvalidRefreshTokenException() {
+        super(3006, "Refresh Token이 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/com/ku/covigator/service/RedisUtil.java
+++ b/src/main/java/com/ku/covigator/service/RedisUtil.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,13 @@ public class RedisUtil {
 
     public void deleteData(String key) {
         template.delete(key);
+    }
+
+    public void deleteAll() {
+        Set<String> keys = template.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            template.delete(keys);
+        }
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ security:
       redirect-uri: ${REDIRECT_URI}
       user-info-url: https://kapi.kakao.com/v2/user/me
       token-url: https://kauth.kakao.com/oauth/token
+  rtr:
+    expiration-length: ${RTK_EXPIRATION_LENGTH}
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.request.*;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
+import com.ku.covigator.dto.response.TokenResponse;
 import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
 import com.ku.covigator.security.jwt.JwtAuthInterceptor;
 import com.ku.covigator.service.AuthService;
@@ -47,10 +48,10 @@ class AuthControllerTest {
         //given
         String email = "covi@naver.com";
         String password = "covigator123";
-        String token = "token";
+        TokenResponse response = new TokenResponse("access-token", "refresh-token");
         PostSignInRequest request = new PostSignInRequest("covi@naver.com", "covigator123");
 
-        given(authService.signIn(email, password)).willReturn(token);
+        given(authService.signIn(email, password)).willReturn(response);
 
         //when //then
         mockMvc.perform(post("/accounts/sign-in")
@@ -58,7 +59,8 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.access_token").value(token));
+                .andExpect(jsonPath("$.access_token").value(response.accessToken()))
+                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()));
     }
 
     @DisplayName("회원 가입한다.")
@@ -82,7 +84,9 @@ class AuthControllerTest {
                 objectMapper.writeValueAsBytes(request)
         );
 
-        given(authService.signUp(any(), any())).willReturn("token");
+        TokenResponse response = new TokenResponse("access-token", "refresh-token");
+
+        given(authService.signUp(any(), any())).willReturn(response);
 
         //when //then
         mockMvc.perform(multipart("/accounts/sign-up")
@@ -92,14 +96,15 @@ class AuthControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.access_token").value("token"));
+                .andExpect(jsonPath("$.access_token").value(response.accessToken()))
+                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()));
     }
 
     @DisplayName("신규 회원에 대한 카카오 로그인을 요청한다.")
     @Test
     void signInKakaoNewMember() throws Exception {
         //given
-        KakaoSignInResponse response = KakaoSignInResponse.fromNewMember("token");
+        KakaoSignInResponse response = KakaoSignInResponse.fromNewMember("access-token", "refresh-token");
         given(authService.signInKakao("code")).willReturn(response);
 
         //when //then
@@ -108,7 +113,8 @@ class AuthControllerTest {
                 ).andDo(print())
                 .andExpectAll(
                         status().isOk(),
-                        jsonPath("$.access_token").value("token"),
+                        jsonPath("$.access_token").value("access-token"),
+                        jsonPath("$.refresh_token").value("refresh-token"),
                         jsonPath("$.is_new").value("True")
                 );
     }
@@ -117,7 +123,7 @@ class AuthControllerTest {
     @Test
     void signInKakaoOldMember() throws Exception {
         //given
-        KakaoSignInResponse response = KakaoSignInResponse.fromOldMember("token");
+        KakaoSignInResponse response = KakaoSignInResponse.fromOldMember("access-token", "refresh-token");
         given(authService.signInKakao("code")).willReturn(response);
 
         //when //then
@@ -126,7 +132,8 @@ class AuthControllerTest {
                 ).andDo(print())
                 .andExpectAll(
                         status().isOk(),
-                        jsonPath("$.access_token").value("token"),
+                        jsonPath("$.access_token").value("access-token"),
+                        jsonPath("$.refresh_token").value("refresh-token"),
                         jsonPath("$.is_new").value("False")
                 );
     }

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.ku.covigator.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ku.covigator.dto.request.*;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.dto.response.TokenResponse;
@@ -149,7 +150,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
-                .andExpectAll(
+                .andExpect(
                         status().isOk()
                 );
     }
@@ -166,7 +167,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
-                .andExpectAll(
+                .andExpect(
                         status().isBadRequest()
                 );
     }
@@ -183,7 +184,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
-                .andExpectAll(
+                .andExpect(
                         status().isOk()
                 );
     }
@@ -204,7 +205,7 @@ class AuthControllerTest {
 
     @DisplayName("비밀번호 변경을 요청한다.")
     @Test
-    void changePassword() throws Exception{
+    void changePassword() throws Exception {
         //given
         ChangePasswordRequest request = new ChangePasswordRequest("covigator123!", "covigator123!");
 
@@ -214,6 +215,26 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @DisplayName("리프레시/액세스 토큰을 재발급한다.")
+    @Test
+    void reissueToken() throws Exception {
+        //given
+        PostReissueTokenRequest request = new PostReissueTokenRequest("refreshtoken");
+        TokenResponse response = new TokenResponse("access_token", "refresh_token");
+        given(authService.reissueToken(any())).willReturn(response);
+
+        //when //then
+        mockMvc.perform(post("/accounts/reissue-token")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.access_token").value(response.accessToken()),
+                        jsonPath("$.refresh_token").value(response.refreshToken())
+                );
     }
 
 }

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import com.ku.covigator.domain.member.Platform;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.dto.response.KakaoTokenResponse;
 import com.ku.covigator.dto.response.KakaoUserInfoResponse;
+import com.ku.covigator.dto.response.TokenResponse;
 import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
 import com.ku.covigator.exception.badrequest.PasswordMismatchException;
 import com.ku.covigator.exception.notfound.NotFoundEmailException;
@@ -68,11 +69,13 @@ class AuthServiceTest {
         memberRepository.save(member);
 
         //when
-        String token = authService.signIn(member.getEmail(), password);
+        TokenResponse response = authService.signIn(member.getEmail(), password);
 
         //then
-        assertNotNull(token);
-        assertFalse(token.isBlank());
+        assertNotNull(response.accessToken());
+        assertNotNull(response.refreshToken());
+        assertFalse(response.accessToken().isBlank());
+        assertFalse(response.refreshToken().isBlank());
     }
 
     @DisplayName("존재하지 않는 회원의 이메일로 로컬 로그인을 시도할 경우 예외가 발생한다.")
@@ -137,8 +140,8 @@ class AuthServiceTest {
                 .thenReturn("https://s3.amazonaws.com/bucket/test-image.jpg");
 
         //when
-        String accessToken = authService.signUp(member, imageFile);
-        Long savedMemberId = Long.parseLong(jwtProvider.getPrincipal(accessToken));
+        TokenResponse response = authService.signUp(member, imageFile);
+        Long savedMemberId = Long.parseLong(jwtProvider.getPrincipal(response.accessToken()));
 
         //then
         assertThat(savedMemberId).isEqualTo(member.getId());


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #68 

## 📝 작업사항

- [x] `Refresh Token` 발급 및 저장 로직 추가 (Redis에 저장)
- [x] `Refresh Token` 재발급 시, Redis에서 기존 토큰 삭제
- [x] `Refresh Token`에 대한 검증 로직 추가
- [x] `Refresh Token` + `Access Token` 재발급 API 추가

## 🚨 주의사항

### Refresh Token 생성 로직 관련

- Refresh Token 생성 로직으로 `UUID.randomUUID().toString()`을 사용한다.

> `JwtTokenProvider`를 통해 토큰을 발급하지 않는 이유는 JwtTokenProvider는 인증을 위한 모든 요청에 대해 payload를 꺼내기 위한 목적이기 때문이지만 `Refresh Token`의 경우에는 그럴 필요가 없기 때문이다. 

https://stackoverflow.com/questions/73823170/refresh-tokens-stored-as-uuid-or-jwt