### PR TITLE
[Feat] 이메일 찾기 - 문자 인증 기능 구현 (with AWS SMS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 	//amazon ses
 	implementation 'com.amazonaws:aws-java-sdk-ses:1.12.772'
 
+	//amazon sns
+	implementation 'software.amazon.awssdk:sns:2.28.22'
+
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/ku/covigator/common/SmsVerificationTemplate.java
+++ b/src/main/java/com/ku/covigator/common/SmsVerificationTemplate.java
@@ -1,0 +1,15 @@
+package com.ku.covigator.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SmsVerificationTemplate {
+
+    CONTENT_PREFIX("[Covigator] 본인확인 인증번호 ["),
+    CONTENT_SUFFIX("] 입니다. \"타인 노출 금지\"");
+
+    private final String text;
+
+}

--- a/src/main/java/com/ku/covigator/config/SnsConfig.java
+++ b/src/main/java/com/ku/covigator/config/SnsConfig.java
@@ -1,0 +1,28 @@
+package com.ku.covigator.config;
+
+import com.ku.covigator.config.properties.AwsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class SnsConfig {
+
+    private final AwsProperties awsProperties;
+
+    @Bean
+    public SnsClient snsClient() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(awsProperties.getAccessKey(), awsProperties.getSecretKey());
+
+        return SnsClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.US_EAST_1)
+                .build();
+    }
+
+}

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 찾기 - 이메일 인증번호 인증")
     @PostMapping("/find-password/verify-code")
-    public ResponseEntity<Void> verifyNumber(@Valid @RequestBody VerifyCodeRequest request) {
+    public ResponseEntity<Void> verifyNumber(@Valid @RequestBody VerifyEmailCodeRequest request) {
         String code = redisUtil.getData(request.email());
         if(!code.equals(request.code())) {
             throw new WrongVerificationCodeException();
@@ -67,6 +67,17 @@ public class AuthController {
     public ResponseEntity<Void> sendMessage(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
                                             @Valid @RequestBody SmsRequest request) {
         authService.sendMessage(memberId, request.phoneNumber());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "이메일 찾기 - 본인확인 인증")
+    @PostMapping("/find-email/verify-code")
+    public ResponseEntity<Void> verifyNumber(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
+                                             @Valid @RequestBody VerifySmsCodeRequest request) {
+        String code = redisUtil.getData(memberId.toString());
+        if(!code.equals(request.code())) {
+            throw new WrongVerificationCodeException();
+        }
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -45,20 +45,28 @@ public class AuthController {
         return ResponseEntity.ok(authService.signInKakao(code));
     }
 
-    @Operation(summary = "비밀번호 찾기 (임시 비밀번호 설정)")
+    @Operation(summary = "비밀번호 찾기 - 이메일 전송")
     @PostMapping("/find-password/send-email")
     public ResponseEntity<Void> findPassword(@Valid @RequestBody FindPasswordRequest request) {
         authService.createVerificationNumber(request.email());
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "이메일 인증번호 인증")
+    @Operation(summary = "비밀번호 찾기 - 이메일 인증번호 인증")
     @PostMapping("/find-password/verify-code")
     public ResponseEntity<Void> verifyNumber(@Valid @RequestBody VerifyCodeRequest request) {
         String code = redisUtil.getData(request.email());
         if(!code.equals(request.code())) {
             throw new WrongVerificationCodeException();
         }
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "이메일 찾기 - 문자 전송")
+    @PostMapping("/find-email/send-message")
+    public ResponseEntity<Void> sendMessage(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
+                                            @Valid @RequestBody SmsRequest request) {
+        authService.sendMessage(memberId, request.phoneNumber());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -46,14 +46,14 @@ public class AuthController {
     }
 
     @Operation(summary = "비밀번호 찾기 (임시 비밀번호 설정)")
-    @PostMapping("/find-password")
+    @PostMapping("/find-password/send-email")
     public ResponseEntity<Void> findPassword(@Valid @RequestBody FindPasswordRequest request) {
         authService.createVerificationNumber(request.email());
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "이메일 인증번호 인증")
-    @PostMapping("/verify-code")
+    @PostMapping("/find-password/verify-code")
     public ResponseEntity<Void> verifyNumber(@Valid @RequestBody VerifyCodeRequest request) {
         String code = redisUtil.getData(request.email());
         if(!code.equals(request.code())) {

--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -28,6 +28,9 @@ public class Member extends BaseTime {
     @Column(name = "email")
     private String email;
 
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
     @Column(name = "password")
     private String password;
 
@@ -50,13 +53,14 @@ public class Member extends BaseTime {
     private List<Dibs> dibs = new ArrayList<>();
 
     @Builder
-    public Member(String nickname, String email, String password, String imageUrl, Platform platform) {
+    public Member(String nickname, String email, String password, String imageUrl, Platform platform, String phoneNumber) {
         this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.imageUrl = imageUrl;
         this.status = Status.ACTIVE;
         this.platform = platform;
+        this.phoneNumber = phoneNumber;
     }
 
     public void savePassword(String password) {

--- a/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostSignUpRequest.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 public record PostSignUpRequest(
         @NotBlank(message = "공백일 수 없습니다.")
         @Size(min = 1, max = 10, message = "글자 길이는 1~10자여야 합니다.") String nickname,
+        @Pattern(regexp = "^01\\d{9}$",
+                message = "올바른 휴대폰 번호 형식이 아닙니다.") String phoneNumber,
         @Email(message = "올바른 이메일 형식이 아닙니다.") String email,
         @Pattern(regexp = "^(?=.*[A-Za-z가-힣])(?=.*\\d)(?=.*[!@#$%^&*()_+~\\-=\\[\\]{};':\",./<>?\\\\|`]).{7,15}$",
                 message = "한글/영문, 숫자, 특수문자를 포함하여 7~15자를 입력해주세요.") String password) {
@@ -21,6 +23,7 @@ public record PostSignUpRequest(
                 .nickname(nickname)
                 .password(password)
                 .platform(Platform.LOCAL)
+                .phoneNumber(phoneNumber)
                 .build();
     }
 }

--- a/src/main/java/com/ku/covigator/dto/request/SmsRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/SmsRequest.java
@@ -1,0 +1,11 @@
+package com.ku.covigator.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Pattern;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SmsRequest(
+        @Pattern(regexp = "^01\\d{9}$",
+                message = "올바른 휴대폰 번호 형식이 아닙니다.") String phoneNumber) {
+}

--- a/src/main/java/com/ku/covigator/dto/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/VerifyEmailCodeRequest.java
@@ -3,7 +3,7 @@ package com.ku.covigator.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 
-public record VerifyCodeRequest(
+public record VerifyEmailCodeRequest(
         @Email(message = "올바른 이메일 형식이 아닙니다.") String email,
         @NotEmpty(message = "공백일 수 없습니다.") String code ) {
 }

--- a/src/main/java/com/ku/covigator/dto/request/VerifySmsCodeRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/VerifySmsCodeRequest.java
@@ -1,0 +1,6 @@
+package com.ku.covigator.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record VerifySmsCodeRequest(@NotEmpty(message = "공백일 수 없습니다.") String code) {
+}

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -168,7 +168,7 @@ public class AuthService {
                         SmsVerificationTemplate.CONTENT_SUFFIX.getText());
 
         // Redis에 인증번호 저장
-        redisUtil.setDataExpire(member.getEmail(), verificationNumber, 60 * 10L);
+        redisUtil.setDataExpire(member.getId().toString(), verificationNumber, 60 * 10L);
 
     }
 

--- a/src/main/java/com/ku/covigator/service/SmsService.java
+++ b/src/main/java/com/ku/covigator/service/SmsService.java
@@ -26,7 +26,7 @@ public class SmsService {
                     .phoneNumber(PHONE_CODE_KOREA + phoneNumber)
                     .build();
 
-            PublishResponse result = snsClient.publish(request);
+            snsClient.publish(request);
         } catch (Exception e) {
             log.error("send sms error: {}", e.getMessage());
         }

--- a/src/main/java/com/ku/covigator/service/SmsService.java
+++ b/src/main/java/com/ku/covigator/service/SmsService.java
@@ -1,0 +1,35 @@
+package com.ku.covigator.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+
+    private final SnsClient snsClient;
+
+    private static final String PHONE_CODE_KOREA = "+82";
+
+    @Async
+    public void sendSms(String phoneNumber, String message) {
+
+        try {
+            PublishRequest request = PublishRequest.builder()
+                    .message(message)
+                    .phoneNumber(PHONE_CODE_KOREA + phoneNumber)
+                    .build();
+
+            PublishResponse result = snsClient.publish(request);
+        } catch (Exception e) {
+            log.error("send sms error: {}", e.getMessage());
+        }
+
+    }
+}

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -158,7 +158,7 @@ class AuthControllerTest {
     @Test
     void writeWrongVerificationCode() throws Exception {
         //given
-        VerifyCodeRequest request = new VerifyCodeRequest("covi@naver.com", "abcd");
+        VerifyEmailCodeRequest request = new VerifyEmailCodeRequest("covi@naver.com", "abcd");
         BDDMockito.given(redisUtil.getData(any())).willReturn("");
 
         //when //then
@@ -175,7 +175,7 @@ class AuthControllerTest {
     @Test
     void writeRightVerificationCode() throws Exception {
         //given
-        VerifyCodeRequest request = new VerifyCodeRequest("covi@naver.com", "abcd");
+        VerifyEmailCodeRequest request = new VerifyEmailCodeRequest("covi@naver.com", "abcd");
         BDDMockito.given(redisUtil.getData(any())).willReturn("abcd");
 
         //when //then

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -145,7 +145,7 @@ class AuthControllerTest {
         FindPasswordRequest request = new FindPasswordRequest("covi@naver.com");
 
         //when //then
-        mockMvc.perform(post("/accounts/find-password")
+        mockMvc.perform(post("/accounts/find-password/send-email")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
@@ -154,15 +154,53 @@ class AuthControllerTest {
                 );
     }
 
-    @DisplayName(" 이메일 인증번호 입력을 잘못하는 경우 상태코드 400을 반환한다..")
+    @DisplayName("이메일 찾기 요청 - 문자 본인 확인")
     @Test
-    void writeWrongVerificationCode() throws Exception {
+    void findEmail() throws Exception {
+        //given
+        SmsRequest request = new SmsRequest("01012341234");
+
+        //when //then
+        mockMvc.perform(post("/accounts/find-email/send-message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(
+                        status().isOk()
+                );
+    }
+
+    @DisplayName(" 이메일 인증번호 입력을 잘못하는 경우 상태코드 400을 반환한다.")
+    @Test
+    void writeWrongVerificationEmailCode() throws Exception {
         //given
         VerifyEmailCodeRequest request = new VerifyEmailCodeRequest("covi@naver.com", "abcd");
         BDDMockito.given(redisUtil.getData(any())).willReturn("");
 
+
         //when //then
-        mockMvc.perform(post("/accounts/verify-code")
+        mockMvc.perform(post("/accounts/find-password/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(
+                        status().isBadRequest()
+                );
+    }
+
+    @DisplayName("본인확인 인증번호 입력을 잘못하는 경우 상태코드 400을 반환한다.")
+    @Test
+    void writeWrongVerificationSmsCode() throws Exception {
+        //given
+        VerifySmsCodeRequest request = new VerifySmsCodeRequest("abcd");
+        BDDMockito.given(redisUtil.getData(any())).willReturn("");
+
+        given(jwtAuthArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(1L);
+        given(jwtAuthArgumentResolver.supportsParameter(any())).willReturn(true);
+
+        //when //then
+        mockMvc.perform(post("/accounts/find-email/verify-code")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
@@ -173,13 +211,34 @@ class AuthControllerTest {
 
     @DisplayName("이메일 인증번호 입력에 성공한다.")
     @Test
-    void writeRightVerificationCode() throws Exception {
+    void writeRightVerificationEmailCode() throws Exception {
         //given
         VerifyEmailCodeRequest request = new VerifyEmailCodeRequest("covi@naver.com", "abcd");
         BDDMockito.given(redisUtil.getData(any())).willReturn("abcd");
 
         //when //then
-        mockMvc.perform(post("/accounts/verify-code")
+        mockMvc.perform(post("/accounts/find-password/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(
+                        status().isOk()
+                );
+    }
+
+    @DisplayName("문자 본인확인 인증번호 입력에 성공한다.")
+    @Test
+    void writeRightVerificationSmsCode() throws Exception {
+        //given
+        VerifySmsCodeRequest request = new VerifySmsCodeRequest("abcd");
+        BDDMockito.given(redisUtil.getData(any())).willReturn("abcd");
+
+        given(jwtAuthArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(1L);
+        given(jwtAuthArgumentResolver.supportsParameter(any())).willReturn(true);
+
+        //when //then
+        mockMvc.perform(post("/accounts/find-email/verify-code")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -1,6 +1,5 @@
 package com.ku.covigator.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ku.covigator.dto.request.*;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.dto.response.TokenResponse;

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -362,9 +362,9 @@ class AuthServiceTest {
         ).isInstanceOf(NotFoundEmailException.class);
     }
 
-    @DisplayName("인증번호 생성시 Redis에 인증번호가 정상적으로 저장된다.")
+    @DisplayName("[이메일] 인증번호 생성시 Redis에 인증번호가 정상적으로 저장된다.")
     @Test
-    void verificationCodeSavedInRedis() {
+    void emailVerificationCodeSavedInRedis() {
         //given
         String email = "covi@naver.com";
         Member member = Member.builder()
@@ -455,6 +455,34 @@ class AuthServiceTest {
         assertThat(redisUtil.existData("refresh_token")).isFalse();
         assertThat(response.refreshToken()).isNotNull();
         assertThat(response.accessToken()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 회원에 대한 인증 번호 문자 전송 요청은 실패한다.")
+    @Test
+    void sendSmsFailForMemberNotExists() {
+        //when //then
+        assertThatThrownBy(() -> authService.sendMessage(1L, "01012341234"))
+                .isInstanceOf(NotFoundMemberException.class);
+    }
+
+    @DisplayName("[문자] 인증번호 생성시 Redis에 인증번호가 정상적으로 저장된다.")
+    @Test
+    void smsVerificationCodeSavedInRedis() {
+        //given
+        Member member = Member.builder()
+                .password("covigator123")
+                .nickname("covi")
+                .imageUrl("www.covi.com")
+                .platform(Platform.LOCAL)
+                .build();
+        Member savedMember = memberRepository.save(member);
+        Long memberId = savedMember.getId();
+
+        //when
+        authService.sendMessage(memberId, "01012341234");
+
+        //then
+        assertThat(redisUtil.existData(memberId.toString())).isTrue();
     }
 
 }


### PR DESCRIPTION
## #️⃣ 이슈

- Issue: #63 

## 📝 작업사항

### API

- 이메일 찾기 요청 API
- 문자 인증번호 인증 API

### 기능 구현
- [x] 문자 인증번호 발송 로직 구현
- [x] 인증번호 저장 로직 구현 - `Redis`

### 인프라
- [x] `AWS SMS` 생성 및 연동
- [x] `AWS SMS` 샌드박스 해제

## 🚨 주의사항
- `AWS SMS`는 서울 리전이 없기 때문에 국제 발신으로 전송된다. `SMS`를 이용한 문자 메시지 발송 시 **국가 코드**를 반드시 입력한다.
- ***인증번호 유효기간: 10분***