### PR TITLE
[Fix] 로그인 및 회원 정보 수정 API 요청/반환 형식 수정

### DIFF
--- a/src/main/java/com/ku/covigator/controller/AuthController.java
+++ b/src/main/java/com/ku/covigator/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.request.*;
+import com.ku.covigator.dto.response.ReissueTokenResponse;
 import com.ku.covigator.dto.response.TokenResponse;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
 import com.ku.covigator.exception.badrequest.PasswordVerificationException;
@@ -94,7 +95,7 @@ public class AuthController {
 
     @Operation(summary = "액세스/리프레시 토큰 재발급")
     @PostMapping("/reissue-token")
-    public ResponseEntity<TokenResponse> reissueToken(@Valid @RequestBody PostReissueTokenRequest request) {
+    public ResponseEntity<ReissueTokenResponse> reissueToken(@Valid @RequestBody PostReissueTokenRequest request) {
         return ResponseEntity.ok(authService.reissueToken(request.refreshToken()));
     }
 }

--- a/src/main/java/com/ku/covigator/controller/MemberController.java
+++ b/src/main/java/com/ku/covigator/controller/MemberController.java
@@ -3,8 +3,10 @@ package com.ku.covigator.controller;
 import com.ku.covigator.dto.request.PatchMemberRequest;
 import com.ku.covigator.dto.request.PostVerifyNicknameRequest;
 import com.ku.covigator.exception.badrequest.PasswordVerificationException;
+import com.ku.covigator.security.jwt.LoggedInMemberId;
 import com.ku.covigator.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,9 @@ public class MemberController {
     private final MemberService memberService;
 
     @Operation(summary = "회원 정보 수정")
-    @PatchMapping("/{member_id}")
+    @PatchMapping()
     public ResponseEntity<Void> updateMember(
-            @PathVariable(value = "member_id") Long memberId,
+            @Parameter(hidden = true) @LoggedInMemberId Long memberId,
             @Valid @RequestBody PatchMemberRequest request
             ) {
 

--- a/src/main/java/com/ku/covigator/dto/response/KakaoSignInResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/KakaoSignInResponse.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoSignInResponse(String accessToken, String isNew, String refreshToken) {
+public record KakaoSignInResponse(String accessToken, String isNew, String refreshToken, String nickname, String email) {
 
-    public static KakaoSignInResponse fromNewMember(String accessToken, String refreshToken) {
-        return new KakaoSignInResponse(accessToken, "True", refreshToken);
+    public static KakaoSignInResponse fromNewMember(String accessToken, String refreshToken, String nickname, String email) {
+        return new KakaoSignInResponse(accessToken, "True", refreshToken, nickname, email);
     }
 
-    public static KakaoSignInResponse fromOldMember(String accessToken, String refreshToken) {
-        return new KakaoSignInResponse(accessToken, "False", refreshToken);
+    public static KakaoSignInResponse fromOldMember(String accessToken, String refreshToken, String nickname, String email) {
+        return new KakaoSignInResponse(accessToken, "False", refreshToken, nickname, email);
     }
 
 }

--- a/src/main/java/com/ku/covigator/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,12 @@
+package com.ku.covigator.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ReissueTokenResponse(String accessToken, String refreshToken) {
+
+    public static ReissueTokenResponse from(final String accessToken, final String refreshToken) {
+        return new ReissueTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/ku/covigator/dto/response/TokenResponse.java
+++ b/src/main/java/com/ku/covigator/dto/response/TokenResponse.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record TokenResponse(String accessToken, String refreshToken) {
+public record TokenResponse(String accessToken, String refreshToken, String nickname, String email) {
 
-    public static TokenResponse from(final String accessToken, final String refreshToken) {
-        return new TokenResponse(accessToken, refreshToken);
+    public static TokenResponse from(final String accessToken, final String refreshToken, final String nickname, final String email) {
+        return new TokenResponse(accessToken, refreshToken, nickname, email);
     }
 }

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -112,7 +112,7 @@ public class AuthService {
             String accessToken = jwtProvider.createToken(savedMember.get().getId().toString());
             String refreshToken = createRefreshToken();
             redisUtil.setDataExpire(refreshToken, String.valueOf(savedMember.get().getId()), rtrProperties.getExpirationLength());
-            return KakaoSignInResponse.fromOldMember(accessToken, refreshToken);
+            return KakaoSignInResponse.fromOldMember(accessToken, refreshToken, savedMember.get().getNickname(), savedMember.get().getEmail());
         }
 
         // 신규 닉네임 생성
@@ -125,7 +125,7 @@ public class AuthService {
         String accessToken = jwtProvider.createToken(newMember.getId().toString());
         String refreshToken = createRefreshToken();
         redisUtil.setDataExpire(refreshToken, String.valueOf(newMember.getId()), rtrProperties.getExpirationLength());
-        return KakaoSignInResponse.fromNewMember(accessToken, refreshToken);
+        return KakaoSignInResponse.fromNewMember(accessToken, refreshToken, newMember.getNickname(), newMember.getEmail());
 
     }
 

--- a/src/main/java/com/ku/covigator/service/AuthService.java
+++ b/src/main/java/com/ku/covigator/service/AuthService.java
@@ -4,10 +4,7 @@ import com.ku.covigator.common.SmsVerificationTemplate;
 import com.ku.covigator.config.properties.RtrProperties;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.member.Platform;
-import com.ku.covigator.dto.response.KakaoSignInResponse;
-import com.ku.covigator.dto.response.KakaoTokenResponse;
-import com.ku.covigator.dto.response.KakaoUserInfoResponse;
-import com.ku.covigator.dto.response.TokenResponse;
+import com.ku.covigator.dto.response.*;
 import com.ku.covigator.exception.badrequest.DuplicateMemberException;
 import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
 import com.ku.covigator.exception.badrequest.InvalidRefreshTokenException;
@@ -64,7 +61,7 @@ public class AuthService {
         String refreshToken = createRefreshToken();
         redisUtil.setDataExpire(refreshToken, String.valueOf(member.getId()), rtrProperties.getExpirationLength());
 
-        return TokenResponse.from(accessToken, refreshToken);
+        return TokenResponse.from(accessToken, refreshToken, member.getNickname(), member.getEmail());
     }
 
     // 로컬 회원가입
@@ -94,7 +91,7 @@ public class AuthService {
         String refreshToken = createRefreshToken();
         redisUtil.setDataExpire(refreshToken, String.valueOf(member.getId()), rtrProperties.getExpirationLength());
 
-        return TokenResponse.from(accessToken, refreshToken);
+        return TokenResponse.from(accessToken, refreshToken, savedMember.getNickname(), savedMember.getEmail());
     }
 
     // 카카오 회원가입
@@ -185,7 +182,7 @@ public class AuthService {
     }
 
     // 액세스 토큰 + Refresh 토큰 재발급
-    public TokenResponse reissueToken(String refreshToken) {
+    public ReissueTokenResponse reissueToken(String refreshToken) {
 
         Long memberId = validateRefreshToken(refreshToken);
 
@@ -197,7 +194,7 @@ public class AuthService {
         // 액세스 토큰 재발급
         String accessToken = jwtProvider.createToken(memberId.toString());
 
-        return TokenResponse.from(accessToken, refreshToken);
+        return ReissueTokenResponse.from(accessToken, refreshToken);
     }
 
     // 닉네임 중복 검증

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.ku.covigator.controller;
 
 import com.ku.covigator.dto.request.*;
 import com.ku.covigator.dto.response.KakaoSignInResponse;
+import com.ku.covigator.dto.response.ReissueTokenResponse;
 import com.ku.covigator.dto.response.TokenResponse;
 import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
 import com.ku.covigator.security.jwt.JwtAuthInterceptor;
@@ -48,7 +49,7 @@ class AuthControllerTest {
         //given
         String email = "covi@naver.com";
         String password = "covigator123";
-        TokenResponse response = new TokenResponse("access-token", "refresh-token");
+        TokenResponse response = new TokenResponse("access-token", "refresh-token","김코비", email);
         PostSignInRequest request = new PostSignInRequest("covi@naver.com", "covigator123");
 
         given(authService.signIn(email, password)).willReturn(response);
@@ -60,7 +61,9 @@ class AuthControllerTest {
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.access_token").value(response.accessToken()))
-                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()));
+                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()))
+                .andExpect(jsonPath("$.nickname").value(response.nickname()))
+                .andExpect(jsonPath("$.email").value(response.email()));
     }
 
     @DisplayName("회원 가입한다.")
@@ -84,7 +87,7 @@ class AuthControllerTest {
                 objectMapper.writeValueAsBytes(request)
         );
 
-        TokenResponse response = new TokenResponse("access-token", "refresh-token");
+        TokenResponse response = new TokenResponse("access-token", "refresh-token", "covi", "covi123@naver.com");
 
         given(authService.signUp(any(), any())).willReturn(response);
 
@@ -97,7 +100,9 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.access_token").value(response.accessToken()))
-                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()));
+                .andExpect(jsonPath("$.refresh_token").value(response.refreshToken()))
+                .andExpect(jsonPath("$.nickname").value(response.nickname()))
+                .andExpect(jsonPath("$.email").value(response.email()));
     }
 
     @DisplayName("신규 회원에 대한 카카오 로그인을 요청한다.")
@@ -280,7 +285,7 @@ class AuthControllerTest {
     void reissueToken() throws Exception {
         //given
         PostReissueTokenRequest request = new PostReissueTokenRequest("refreshtoken");
-        TokenResponse response = new TokenResponse("access_token", "refresh_token");
+        ReissueTokenResponse response = new ReissueTokenResponse("access_token", "refresh_token");
         given(authService.reissueToken(any())).willReturn(response);
 
         //when //then

--- a/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/AuthControllerTest.java
@@ -109,7 +109,7 @@ class AuthControllerTest {
     @Test
     void signInKakaoNewMember() throws Exception {
         //given
-        KakaoSignInResponse response = KakaoSignInResponse.fromNewMember("access-token", "refresh-token");
+        KakaoSignInResponse response = KakaoSignInResponse.fromNewMember("access-token", "refresh-token", "covi", "covigator@naver.com");
         given(authService.signInKakao("code")).willReturn(response);
 
         //when //then
@@ -120,7 +120,9 @@ class AuthControllerTest {
                         status().isOk(),
                         jsonPath("$.access_token").value("access-token"),
                         jsonPath("$.refresh_token").value("refresh-token"),
-                        jsonPath("$.is_new").value("True")
+                        jsonPath("$.is_new").value("True"),
+                        jsonPath("$.nickname").value("covi"),
+                        jsonPath("$.email").value("covigator@naver.com")
                 );
     }
 
@@ -128,7 +130,7 @@ class AuthControllerTest {
     @Test
     void signInKakaoOldMember() throws Exception {
         //given
-        KakaoSignInResponse response = KakaoSignInResponse.fromOldMember("access-token", "refresh-token");
+        KakaoSignInResponse response = KakaoSignInResponse.fromOldMember("access-token", "refresh-token", "covi", "covigator@naver.com");
         given(authService.signInKakao("code")).willReturn(response);
 
         //when //then
@@ -139,7 +141,9 @@ class AuthControllerTest {
                         status().isOk(),
                         jsonPath("$.access_token").value("access-token"),
                         jsonPath("$.refresh_token").value("refresh-token"),
-                        jsonPath("$.is_new").value("False")
+                        jsonPath("$.is_new").value("False"),
+                        jsonPath("$.nickname").value("covi"),
+                        jsonPath("$.email").value("covigator@naver.com")
                 );
     }
 

--- a/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
+++ b/src/test/java/com/ku/covigator/controller/MemberControllerTest.java
@@ -3,6 +3,8 @@ package com.ku.covigator.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ku.covigator.dto.request.PatchMemberRequest;
 import com.ku.covigator.dto.request.PostVerifyNicknameRequest;
+import com.ku.covigator.security.jwt.JwtAuthArgumentResolver;
+import com.ku.covigator.security.jwt.JwtAuthInterceptor;
 import com.ku.covigator.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,12 +15,14 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ComponentScan({"com.ku.covigator.support.slack", "com.ku.covigator.security.jwt"})
+@ComponentScan("com.ku.covigator.support.slack")
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest {
 
@@ -28,6 +32,10 @@ class MemberControllerTest {
     private ObjectMapper objectMapper;
     @MockBean
     private MemberService memberService;
+    @MockBean
+    private JwtAuthInterceptor jwtAuthInterceptor;
+    @MockBean
+    private JwtAuthArgumentResolver jwtAuthArgumentResolver;
 
     @DisplayName("회원 정보 수정을 요청한다.")
     @Test
@@ -39,8 +47,12 @@ class MemberControllerTest {
                 .passwordVerification("covigator123!")
                 .build();
 
+        given(jwtAuthArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(1L);
+        given(jwtAuthArgumentResolver.supportsParameter(any())).willReturn(true);
+
         //when //then
-        mockMvc.perform(patch("/members/{member_id}", 1L)
+        mockMvc.perform(patch("/members")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
@@ -58,7 +70,7 @@ class MemberControllerTest {
                 .build();
 
         //when //then
-        mockMvc.perform(patch("/members/{member_id}", 1L)
+        mockMvc.perform(patch("/members", 1L)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())

--- a/src/test/java/com/ku/covigator/service/AuthServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/AuthServiceTest.java
@@ -2,10 +2,7 @@ package com.ku.covigator.service;
 
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.member.Platform;
-import com.ku.covigator.dto.response.KakaoSignInResponse;
-import com.ku.covigator.dto.response.KakaoTokenResponse;
-import com.ku.covigator.dto.response.KakaoUserInfoResponse;
-import com.ku.covigator.dto.response.TokenResponse;
+import com.ku.covigator.dto.response.*;
 import com.ku.covigator.exception.badrequest.DuplicateMemberNicknameException;
 import com.ku.covigator.exception.badrequest.InvalidRefreshTokenException;
 import com.ku.covigator.exception.badrequest.PasswordMismatchException;
@@ -449,7 +446,7 @@ class AuthServiceTest {
         redisUtil.setDataExpire("refresh_token", savedMember.getId().toString(), 3600 * 1000);
 
         //when
-        TokenResponse response = authService.reissueToken("refresh_token");
+        ReissueTokenResponse response = authService.reissueToken("refresh_token");
 
         //then
         assertThat(redisUtil.existData("refresh_token")).isFalse();


### PR DESCRIPTION
## 📝 작업사항

- [X] 로그인/회원가입 API response에 사용자 닉네임, 이메일 추가
- [X] 회원 정보 수정 API 요청 형식 변경 - Path Variable이 아닌 토큰을 통해 memberId 추출
