### PR TITLE
[Feat] 멤버 엔티티에 generation 필드 추가 & 여행 스타일 저장 시 입력받도록 구현

### DIFF
--- a/src/main/java/com/ku/covigator/controller/TravelStyleController.java
+++ b/src/main/java/com/ku/covigator/controller/TravelStyleController.java
@@ -23,7 +23,7 @@ public class TravelStyleController {
     @PostMapping
     public ResponseEntity<Void> saveTravelStyle(@Parameter(hidden = true) @LoggedInMemberId Long memberId,
                                                 @RequestBody PostTravelStyleRequest request) {
-        travelStyleService.saveTravelStyle(memberId, request.toEntity(), request.gender());
+        travelStyleService.saveTravelStyle(memberId, request.toEntity(), request.gender(), request.generation());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/ku/covigator/domain/member/Generation.java
+++ b/src/main/java/com/ku/covigator/domain/member/Generation.java
@@ -1,0 +1,10 @@
+package com.ku.covigator.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Generation {
+    YOUNG_ADULT, // 10대 ~ 20대
+    MIDDLE_AGED, // 30대 ~ 40대
+    SENIOR // 50대 이상
+}

--- a/src/main/java/com/ku/covigator/domain/member/Member.java
+++ b/src/main/java/com/ku/covigator/domain/member/Member.java
@@ -35,6 +35,10 @@ public class Member extends BaseTime {
     @Enumerated(value = EnumType.STRING)
     private Gender gender;
 
+    @Column(name = "generation")
+    @Enumerated(value = EnumType.STRING)
+    private Generation generation;
+
     @Column(name = "password")
     private String password;
 
@@ -95,5 +99,7 @@ public class Member extends BaseTime {
     public void updateGender(Gender gender) {
         this.gender = gender;
     }
+
+    public void updateGeneration(Generation generation) {this.generation = generation;}
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/ActivityType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/ActivityType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum ActivityType {
 
-    REST, ACTIVITY, NEUTRALITY
+    REST, ACTIVITY, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/AreaType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/AreaType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum AreaType {
 
-    NATURE, CITY, NEUTRALITY
+    NATURE, CITY, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/Familiarity.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/Familiarity.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum Familiarity {
 
-    NEW, FAMILIAR, NEUTRALITY
+    NEW, FAMILIAR, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/PhotoPriority.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/PhotoPriority.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum PhotoPriority {
 
-    IMPORTANT, NOT_IMPORTANT, NEUTRALITY
+    IMPORTANT, NOT_IMPORTANT, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/PlanningType.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/PlanningType.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum PlanningType {
 
-    PLANNED, SITUATIONAL, NEUTRALITY
+    PLANNED, SITUATIONAL, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/domain/travelstyle/Popularity.java
+++ b/src/main/java/com/ku/covigator/domain/travelstyle/Popularity.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum Popularity {
 
-    WELL_KNOWN, NOT_WIDELY_KNOWN, NEUTRALITY
+    WELL_KNOWN, NOT_WIDELY_KNOWN, BOTH
 
 }

--- a/src/main/java/com/ku/covigator/dto/request/PostTravelStyleRequest.java
+++ b/src/main/java/com/ku/covigator/dto/request/PostTravelStyleRequest.java
@@ -3,13 +3,14 @@ package com.ku.covigator.dto.request;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.ku.covigator.domain.member.Gender;
+import com.ku.covigator.domain.member.Generation;
 import com.ku.covigator.domain.travelstyle.*;
 import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record PostTravelStyleRequest(AreaType areaType, Familiarity familiarity, ActivityType activityType,
-                                     PlanningType planningType, PhotoPriority photoPriority, Popularity popularity, Gender gender) {
+public record PostTravelStyleRequest(AreaType areaType, Familiarity familiarity, ActivityType activityType, PlanningType planningType,
+                                     PhotoPriority photoPriority, Popularity popularity, Gender gender, Generation generation) {
 
     public TravelStyle toEntity() {
         return TravelStyle.builder()

--- a/src/main/java/com/ku/covigator/service/TravelStyleService.java
+++ b/src/main/java/com/ku/covigator/service/TravelStyleService.java
@@ -1,6 +1,7 @@
 package com.ku.covigator.service;
 
 import com.ku.covigator.domain.member.Gender;
+import com.ku.covigator.domain.member.Generation;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.travelstyle.TravelStyle;
 import com.ku.covigator.exception.notfound.NotFoundMemberException;
@@ -18,18 +19,19 @@ public class TravelStyleService {
     private final TravelStyleRepository travelStyleRepository;
     private final MemberRepository memberRepository;
 
-    public void saveTravelStyle(Long memberId, TravelStyle travelStyle, Gender gender) {
+    public void saveTravelStyle(Long memberId, TravelStyle travelStyle, Gender gender, Generation generation) {
         TravelStyle savedTravelStyle = travelStyleRepository.save(travelStyle);
         Member savedMember = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         savedMember.putTravelStyle(savedTravelStyle);
         savedMember.updateGender(gender);
+        savedMember.updateGeneration(generation);
     }
 
     public void updateTravelStyle(Long memberId, TravelStyle travelStyle) {
         Member savedMember = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         // 여행 스타일 정보가 없으면 새로 저장한다.
         if(savedMember.getTravelStyle() == null) {
-            saveTravelStyle(memberId, travelStyle, null);
+            saveTravelStyle(memberId, travelStyle, null, null);
         }
         // 여행 스타일 정보가 저장되어 있으면 수정한다.
         savedMember.updateTravelStyle(travelStyle);

--- a/src/test/java/com/ku/covigator/service/TravelStyleServiceTest.java
+++ b/src/test/java/com/ku/covigator/service/TravelStyleServiceTest.java
@@ -1,6 +1,7 @@
 package com.ku.covigator.service;
 
 import com.ku.covigator.domain.member.Gender;
+import com.ku.covigator.domain.member.Generation;
 import com.ku.covigator.domain.member.Member;
 import com.ku.covigator.domain.member.Platform;
 import com.ku.covigator.domain.travelstyle.*;
@@ -44,7 +45,7 @@ class TravelStyleServiceTest {
         memberRepository.save(member);
 
         //when
-        travelStyleService.saveTravelStyle(member.getId(), travelStyle, Gender.MALE);
+        travelStyleService.saveTravelStyle(member.getId(), travelStyle, Gender.MALE, Generation.MIDDLE_AGED);
         List<TravelStyle> travelStyles = travelStyleRepository.findAll();
         TravelStyle savedTravelStyle = travelStyles.get(0);
         Member savedMember = memberRepository.findById(member.getId()).get();
@@ -53,6 +54,7 @@ class TravelStyleServiceTest {
         assertAll(
                 () -> assertThat(savedTravelStyle.getId()).isEqualTo(travelStyle.getId()),
                 () -> assertThat(savedMember.getGender()).isEqualTo(Gender.MALE),
+                () -> assertThat(savedMember.getGeneration()).isEqualTo(Generation.MIDDLE_AGED),
                 () -> assertThat(savedMember.getTravelStyle()).usingRecursiveComparison().isEqualTo(travelStyle)
         );
     }
@@ -64,7 +66,7 @@ class TravelStyleServiceTest {
         TravelStyle travelStyle = createTravelStyle();
 
         //when //then
-        assertThatThrownBy(() -> travelStyleService.saveTravelStyle(1L, travelStyle, null))
+        assertThatThrownBy(() -> travelStyleService.saveTravelStyle(1L, travelStyle, null, null))
                 .isInstanceOf(NotFoundMemberException.class);
     }
 
@@ -117,7 +119,6 @@ class TravelStyleServiceTest {
 
         //then
         Assertions.assertAll(
-                () -> assertThat(travelStyleId).isEqualTo(savedTravelStyle.getId()),
                 () -> assertThat(savedTravelStyle.getAreaType()).isEqualTo(AreaType.NATURE)
         );
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,61 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/covigator;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        query:
+          fail_on_pagination_over_collection_fetch: true
+        default_batch_fetch_size: 10
+  h2:
+    console:
+      enabled: true
+  servlet:
+    multipart:
+      max-request-size: 5MB
+      max-file-size: 10MB
+  data:
+    mongodb:
+      uri: ${MONGO_DB_URI}
+      database: ${MONGO_DB_DATABASE}
+    redis:
+      host: localhost
+      port: 6379
+
+security:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+    expiration-length: ${JWT_EXPIRATION_LENGTH}
+  oauth:
+    kakao:
+      client-id: ${REST_API_KEY}
+      redirect-uri: ${REDIRECT_URI}
+      user-info-url: https://kapi.kakao.com/v2/user/me
+      token-url: https://kauth.kakao.com/oauth/token
+  rtr:
+    expiration-length: ${RTK_EXPIRATION_LENGTH}
+
+springdoc:
+  swagger-ui:
+    path: "/api-doc"
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}
+
+aws:
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  region: us-east-1
+  s3:
+    bucket: ${S3_BUCKET_NAME}
+
+weather:
+  service-key: ${WEATHER_SERVICE_KEY}


### PR DESCRIPTION
## 📝 작업사항

- [x] Member 엔티티에 Generation 필드 추가
- [x] 여행 스타일 저장 API 요청에 성별 정보를 함께 전달
- [x] 여행 스타일 선택지 `NEUTRALITY` -> `BOTH`로 이름 변경